### PR TITLE
Add support to build docs locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ ICON_PROGRESS = [-]
 NODE ?= $(shell command -v node)
 NPM ?= $(shell command -v npm)
 NPX ?= $(shell command -v npx)
-ANTORA_PLAYBOOK := $(shell pwd)/docs/antora-playbook.yml
+DOC_BUILD_DIR=docs/build
+ANTORA_PLAYBOOK := $(shell pwd)/docs/antora-playbook.local.yml
 #-----------------------------------------------------------------------------
 # Dev commands
 #-----------------------------------------------------------------------------
@@ -54,6 +55,11 @@ lint-full-report:
 # Documentation commands
 #-----------------------------------------------------------------------------
 build-docs: run-antora
+
+clean-docs:
+	@echo -e "$(BUILD_PRINT)$(ICON_PROGRESS) Cleaning up Antora build...$(END_BUILD_PRINT)"
+	rm -rfv $(DOC_BUILD_DIR)
+	@echo -e "$(BUILD_PRINT)$(ICON_DONE) Antora build successfully cleaned!$(END_BUILD_PRINT)"
 
 check-node:
 ifeq ($(NODE),)

--- a/docs/antora-playbook.local.yml
+++ b/docs/antora-playbook.local.yml
@@ -1,0 +1,22 @@
+site:
+  title: Mapping Suite SDK Documentation
+  url: https://mapping-suite-sdk.readthedocs.io
+  start_page: mapping-suite-sdk::index.adoc
+
+content:
+  sources:
+    - url: ./..
+      start_path: docs
+      edit_url: false
+
+ui:
+  bundle:
+    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+    snapshot: true
+
+asciidoc:
+  attributes:
+    experimental: ''
+    idprefix: ''
+    idseparator: '-'
+    page-pagination: ''


### PR DESCRIPTION
The online docs are built using the readthedocs service, and so the Makefile target can simply serve the local builder.

- Local-specific Antora config file
- Update Makefile to use new local config file
- Add a clean target for docs