### PR TITLE
Ignorable output files

### DIFF
--- a/mapping_suite_sdk/adapters/loader.py
+++ b/mapping_suite_sdk/adapters/loader.py
@@ -288,7 +288,8 @@ class TestResultSuiteLoader(MappingPackageAssetLoader):
                         path=test_data_report.relative_to(package_folder_path),
                         content=load_file_by_extensions(test_data_report)
                     ) for test_data_report in
-                        (test_data_suites_result / RELATIVE_TEST_DATA_REPORTS_OUTPUT_PATH).iterdir() if test_data_report.is_file()],
+                        (test_data_suites_result / RELATIVE_TEST_DATA_REPORTS_OUTPUT_PATH).iterdir() if
+                        test_data_report.is_file()],
                     test_data_output=TestDataResultAsset(
                         path=next(test_data_suites_result.glob('*.ttl'), None).relative_to(package_folder_path),
                         content=load_file_by_extensions(next(test_data_suites_result.glob('*.ttl'), None))),
@@ -330,6 +331,19 @@ class MappingPackageLoader(MappingPackageAssetLoader):
 
     Coordinates the loading of all components of a mapping package using specialized loaders.
     """
+
+    def __init__(self,
+                 include_test_data: bool = True,
+                 include_output: bool = True,
+                 ):
+        self.include_test_data = include_test_data
+        self.include_output = include_output
+
+    def __eq__(self, other):
+        if isinstance(other, MappingPackageLoader):
+            return (self.include_test_data == other.include_test_data and
+                    self.include_output == other.include_output)
+        return False
 
     def load(self, package_folder_path: Path) -> MappingPackage:
         """Load all components of a mapping package.
@@ -389,7 +403,10 @@ class MappingPackageLoader(MappingPackageAssetLoader):
         except Exception as e:
             _process_exception(e)
         try:
-            test_data_suites = TestDataSuitesLoader().load(package_folder_path)
+            if self.include_test_data:
+                test_data_suites = TestDataSuitesLoader().load(package_folder_path)
+            else:
+                test_data_suites = []
         except Exception as e:
             _process_exception(e)
         try:
@@ -401,7 +418,10 @@ class MappingPackageLoader(MappingPackageAssetLoader):
         except Exception as e:
             _process_exception(e)
         try:
-            test_results = TestResultSuiteLoader().load(package_folder_path)
+            if self.include_output:
+                test_results = TestResultSuiteLoader().load(package_folder_path)
+            else:
+                test_results = TestResultSuite(path=package_folder_path / RELATIVE_TEST_RESULT_PATH)
         except Exception as e:
             _process_exception(e)
 

--- a/mapping_suite_sdk/adapters/validator.py
+++ b/mapping_suite_sdk/adapters/validator.py
@@ -57,9 +57,9 @@ class MPStructuralValidationStep(MPValidationStepABC):
         # Most of structural validation where done by model itself (using Pydantic)
 
         try:
-            assert mapping_package.test_data_suites
-            for suite in mapping_package.test_data_suites:
-                assert suite.files
+            if mapping_package.test_data_suites:
+                for suite in mapping_package.test_data_suites:
+                    assert suite.files
 
             assert mapping_package.test_suites_shacl
             for suite in mapping_package.test_suites_shacl:
@@ -68,6 +68,12 @@ class MPStructuralValidationStep(MPValidationStepABC):
             assert mapping_package.test_suites_sparql
             for suite in mapping_package.test_suites_sparql:
                 assert suite.files
+
+            if mapping_package.test_results:
+                for suite in mapping_package.test_results.result_suites:
+                    assert suite.files
+
+        #TODO: structural validation also must check relation between test data and results
 
         except AssertionError:
             raise MPStructuralValidationException("Mapping Package validation error:\nThere are empty suites")

--- a/mapping_suite_sdk/entrypoints/cli/validate.py
+++ b/mapping_suite_sdk/entrypoints/cli/validate.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import typer
 
 from mapping_suite_sdk import validate_mapping_package_from_archive, validate_bulk_mapping_packages_from_github, \
-    validate_bulk_mapping_packages_from_folder
+    validate_bulk_mapping_packages_from_folder, MappingPackageLoader
 from mapping_suite_sdk.entrypoints.cli import typer_verbose_callback
 from mapping_suite_sdk.vars import MSSDK_TYPER_DEFAULT_ARGS, MSSDK_TYPER_COMMANDS_DEFAULT_ARGS, \
     MSSDK_LOGGING_MESSAGE_FORMAT
@@ -21,6 +21,9 @@ mssdk_cli_validate_subcommand = typer.Typer(**MSSDK_TYPER_DEFAULT_ARGS,
                                        help="Validate a single archive.")
 def mssdk_cli_validate_mapping_package_from_archive(
         mapping_package_archive_path: Path = typer.Argument(..., exists=True),
+        include_test_data: bool = typer.Option(False, "--include-test-data",
+                                               help="Whether to load test data folder or not"),
+        include_output: bool = typer.Option(False, "--include-output", help="Whether to load output folder or not"),
         verbose: bool = typer.Option(False, "--verbose", "-v",
                                      is_eager=True,
                                      callback=typer_verbose_callback,
@@ -30,11 +33,17 @@ def mssdk_cli_validate_mapping_package_from_archive(
     logger.debug(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=mapping_package_archive_path,
                                                      message="Running mapping package validation from archive using command line"))
 
-    all_valid: bool = validate_mapping_package_from_archive(mapping_package_archive_path=mapping_package_archive_path)
+    all_valid: bool = validate_mapping_package_from_archive(mapping_package_archive_path=mapping_package_archive_path,
+                                                            mapping_package_loader=MappingPackageLoader(
+                                                                include_test_data=include_test_data,
+                                                                include_output=include_output),
+                                                            )
     if all_valid:
-        logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=mapping_package_archive_path, message="Running mapping package validation from archive using command line finished successfully.\n✅ The package is valid!"))
+        logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=mapping_package_archive_path,
+                                                        message="Running mapping package validation from archive using command line finished successfully.\n✅ The package is valid!"))
     else:
-        logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=mapping_package_archive_path, message="Running mapping package validation from archive using command line finished successfully.\n❌ The package is invalid! Please check the logs."))
+        logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=mapping_package_archive_path,
+                                                        message="Running mapping package validation from archive using command line finished successfully.\n❌ The package is invalid! Please check the logs."))
 
     logger.debug(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=mapping_package_archive_path,
                                                      message="DONE Running mapping package validation from archive using command line"))
@@ -46,6 +55,9 @@ def mssdk_cli_validate_mapping_package_from_archive(
 def mssdk_cli_validate_mapping_packages_from_github(
         github_repository_url: str = typer.Argument(..., help="GitHub repository URL"),
         packages_path_pattern: str = typer.Argument(..., help="Package path pattern. Example: mappings/*"),
+        include_test_data: bool = typer.Option(False, "--include-test-data",
+                                               help="Whether to load test data folder or not"),
+        include_output: bool = typer.Option(False, "--include-output", help="Whether to load output folder or not"),
         branch_or_tag_name: str = typer.Option(None, "--branch", "-b", help="Branch or tag name"),
         verbose: bool = typer.Option(False, "--verbose", "-v",
                                      is_eager=True,
@@ -56,7 +68,10 @@ def mssdk_cli_validate_mapping_packages_from_github(
     validate_bulk_mapping_packages_from_github(
         github_repository_url=github_repository_url,
         packages_path_pattern=packages_path_pattern,
-        branch_or_tag_name=branch_or_tag_name
+        branch_or_tag_name=branch_or_tag_name,
+        mapping_package_loader=MappingPackageLoader(
+            include_test_data=include_test_data,
+            include_output=include_output),
     )
 
 
@@ -65,17 +80,29 @@ def mssdk_cli_validate_mapping_packages_from_github(
                                        help="Validate a list of mapping packages folders from folder.")
 def mssdk_cli_validate_mapping_packages_from_folder(
         folder_path: Path = typer.Argument(..., help="Folder containing mapping packages folders. Example: mappings/"),
-        update_hash: bool = typer.Option(False, "--update-hash", "-u", help="Update hash for packages that has invalid hash."),
+        update_hash: bool = typer.Option(False, "--update-hash", "-u",
+                                         help="Update hash for packages that has invalid hash."),
+        include_test_data: bool = typer.Option(False, "--include-test-data",
+                                               help="Whether to load test data folder or not"),
+        include_output: bool = typer.Option(False, "--include-output", help="Whether to load output folder or not"),
         verbose: bool = typer.Option(False, "--verbose", "-v",
                                      is_eager=True,
                                      callback=typer_verbose_callback,
                                      help="Show debug logs."),
 ) -> None:
     """Validate mapping packages from folder."""
-    logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=folder_path, message="Running mapping package validation from folder using command line"))
-
-    all_valid: bool = validate_bulk_mapping_packages_from_folder(mapping_packages_folder_path=folder_path, update_hash=update_hash)
+    logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=folder_path,
+                                                    message="Running mapping package validation from folder using command line"))
+    mapping_package_loader = MappingPackageLoader(
+        include_test_data=include_test_data,
+        include_output=include_output
+    )
+    all_valid: bool = validate_bulk_mapping_packages_from_folder(mapping_packages_folder_path=folder_path,
+                                                                 update_hash=update_hash,
+                                                                 mapping_package_loader=mapping_package_loader)
     if all_valid:
-        logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=folder_path, message="Running mapping package validation from folder using command line finished successfully.\n✅ All packages are valid!"))
+        logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=folder_path,
+                                                        message="Running mapping package validation from folder using command line finished successfully.\n✅ All packages are valid!"))
     else:
-        logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=folder_path, message="Running mapping package validation from folder using command line finished successfully.\n❌ There are invalid packages! Please check the logs."))
+        logger.info(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=folder_path,
+                                                        message="Running mapping package validation from folder using command line finished successfully.\n❌ There are invalid packages! Please check the logs."))

--- a/mapping_suite_sdk/services/validate_mapping_package.py
+++ b/mapping_suite_sdk/services/validate_mapping_package.py
@@ -68,7 +68,8 @@ def validate_mapping_package_from_archive(
 @traced_routine
 def validate_mapping_package_from_folder(
         mapping_package_folder_path: Path,
-        mp_validator: Optional[MappingPackageValidator] = None) -> Literal[True] | NoReturn:
+        mp_validator: Optional[MappingPackageValidator] = None,
+        mapping_package_loader: Optional[MappingPackageAssetLoader] = None) -> Literal[True] | NoReturn:
     if not mapping_package_folder_path.exists():
         message: str = f"Cannot validate package from folder. Folder path does not exist: {mapping_package_folder_path}"
         logger.error(MSSDK_LOGGING_MESSAGE_FORMAT.format(package_source=mapping_package_folder_path,
@@ -82,7 +83,9 @@ def validate_mapping_package_from_folder(
         raise NotADirectoryError(message)
 
     mapping_package: MappingPackage = load_mapping_package_from_folder(
-        mapping_package_folder_path=mapping_package_folder_path)
+        mapping_package_folder_path=mapping_package_folder_path,
+        mapping_package_loader=mapping_package_loader,
+    )
 
     return validate_mapping_package(mapping_package=mapping_package, mp_validator=mp_validator)
 
@@ -91,6 +94,7 @@ def validate_mapping_package_from_folder(
 def validate_bulk_mapping_packages_from_folder(
         mapping_packages_folder_path: Path,
         mp_validator: Optional[MappingPackageValidator] = None,
+        mapping_package_loader: Optional[MappingPackageAssetLoader] = None,
         update_hash: bool = False,
 ) -> bool | NoReturn:
     if not mapping_packages_folder_path.exists():
@@ -108,7 +112,9 @@ def validate_bulk_mapping_packages_from_folder(
     all_valid: bool = True
     for mp_folder in mapping_packages_folder_path.iterdir():
         try:
-            validate_mapping_package_from_folder(mapping_package_folder_path=mp_folder, mp_validator=mp_validator)
+            validate_mapping_package_from_folder(mapping_package_folder_path=mp_folder,
+                                                 mp_validator=mp_validator,
+                                                 mapping_package_loader=mapping_package_loader,)
         except MPHashValidationException as hash_validation_exception:
             # TODO: Temporary solution. This logic needs to be in the validator.
             #  It will be done there when MSSDK will have Full MP support (currently no support for output folder)
@@ -138,7 +144,7 @@ def validate_bulk_mapping_packages_from_github(
         packages_path_pattern: str,
         branch_or_tag_name: Optional[str] = None,
         github_package_extractor: Optional[GithubPackageExtractor] = None,
-        mapping_package_loader: [MappingPackageAssetLoader] = None,
+        mapping_package_loader: MappingPackageAssetLoader = None,
         mp_validator: Optional[MappingPackageValidator] = None) -> NoReturn:
     if not github_repository_url:
         message: str = "Cannot validate packages from github. Repository URL is empty"

--- a/tests/unit/entrypoints/cli/test_validation_cli.py
+++ b/tests/unit/entrypoints/cli/test_validation_cli.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner
 
+from mapping_suite_sdk import MappingPackageLoader
 from mapping_suite_sdk.entrypoints.cli.validate import (
     mssdk_cli_validate_subcommand
 )
@@ -26,7 +27,23 @@ def test_validate_from_archive_command(mock_validate,
 
     assert result.exit_code == 0
 
-    mock_validate.assert_called_once_with(mapping_package_archive_path=dummy_mapping_package_path)
+    mock_validate.assert_called_once_with(mapping_package_archive_path=dummy_mapping_package_path,
+                                          mapping_package_loader=MappingPackageLoader(include_test_data=False, include_output=False))
+
+
+@patch("mapping_suite_sdk.entrypoints.cli.validate.validate_mapping_package_from_archive")
+def test_validate_from_archive_command_including_assets_flags(mock_validate,
+                                       typer_cli_runner: CliRunner,
+                                       dummy_mapping_package_path: Path) -> None:
+    result = typer_cli_runner.invoke(
+        mssdk_cli_validate_subcommand,
+        ["from-archive", str(dummy_mapping_package_path), "--include-test-data", "--include-output"]
+    )
+
+    assert result.exit_code == 0
+
+    mock_validate.assert_called_once_with(mapping_package_archive_path=dummy_mapping_package_path,
+                                          mapping_package_loader=MappingPackageLoader(include_test_data=True, include_output=True))
 
 
 @patch("mapping_suite_sdk.entrypoints.cli.validate.validate_bulk_mapping_packages_from_github")
@@ -35,10 +52,10 @@ def test_validate_from_github_command(mock_validate,
                                       dummy_get_all_packages_pattern: str,
                                       dummy_github_branch_name: str,
                                       typer_cli_runner: CliRunner) -> None:
-
     result = typer_cli_runner.invoke(
         mssdk_cli_validate_subcommand,
-        ["from-github", dummy_invalid_github_repo_url, dummy_get_all_packages_pattern, "--branch", dummy_github_branch_name]
+        ["from-github", dummy_invalid_github_repo_url, dummy_get_all_packages_pattern, "--branch",
+         dummy_github_branch_name]
     )
 
     assert result.exit_code == 0
@@ -46,16 +63,40 @@ def test_validate_from_github_command(mock_validate,
     mock_validate.assert_called_once_with(
         github_repository_url=dummy_invalid_github_repo_url,
         packages_path_pattern=dummy_get_all_packages_pattern,
-        branch_or_tag_name=dummy_github_branch_name
+        branch_or_tag_name=dummy_github_branch_name,
+        mapping_package_loader=MappingPackageLoader(
+            include_test_data=False,
+            include_output=False)
     )
 
+@patch("mapping_suite_sdk.entrypoints.cli.validate.validate_bulk_mapping_packages_from_github")
+def test_validate_from_github_command_including_assets_flags(mock_validate,
+                                      dummy_invalid_github_repo_url: str,
+                                      dummy_get_all_packages_pattern: str,
+                                      dummy_github_branch_name: str,
+                                      typer_cli_runner: CliRunner) -> None:
+    result = typer_cli_runner.invoke(
+        mssdk_cli_validate_subcommand,
+        ["from-github", dummy_invalid_github_repo_url, dummy_get_all_packages_pattern, "--branch",
+         dummy_github_branch_name, "--include-test-data", "--include-output"]
+    )
+
+    assert result.exit_code == 0
+
+    mock_validate.assert_called_once_with(
+        github_repository_url=dummy_invalid_github_repo_url,
+        packages_path_pattern=dummy_get_all_packages_pattern,
+        branch_or_tag_name=dummy_github_branch_name,
+        mapping_package_loader=MappingPackageLoader(
+            include_test_data=True,
+            include_output=True)
+    )
 
 @patch("mapping_suite_sdk.entrypoints.cli.validate.validate_bulk_mapping_packages_from_github")
 def test_validate_from_github_command_without_branch(mock_validate,
                                                      dummy_invalid_github_repo_url: str,
                                                      dummy_get_all_packages_pattern: str,
                                                      typer_cli_runner: CliRunner) -> None:
-
     result = typer_cli_runner.invoke(
         mssdk_cli_validate_subcommand,
         ["from-github", dummy_invalid_github_repo_url, dummy_get_all_packages_pattern]
@@ -66,7 +107,10 @@ def test_validate_from_github_command_without_branch(mock_validate,
     mock_validate.assert_called_once_with(
         github_repository_url=dummy_invalid_github_repo_url,
         packages_path_pattern=dummy_get_all_packages_pattern,
-        branch_or_tag_name=None
+        branch_or_tag_name=None,
+        mapping_package_loader=MappingPackageLoader(
+            include_test_data=False,
+            include_output=False)
     )
 
 
@@ -74,7 +118,6 @@ def test_validate_from_github_command_without_branch(mock_validate,
 def test_validate_from_folder_command(mock_validate,
                                       typer_cli_runner: CliRunner,
                                       tmp_path: Path) -> None:
-
     mock_validate.return_value = True
 
     result = typer_cli_runner.invoke(
@@ -86,7 +129,28 @@ def test_validate_from_folder_command(mock_validate,
 
     mock_validate.assert_called_once_with(
         mapping_packages_folder_path=tmp_path,
-        update_hash=False
+        update_hash=False,
+        mapping_package_loader=MappingPackageLoader(include_test_data=False, include_output=False)
+    )
+
+
+@patch("mapping_suite_sdk.entrypoints.cli.validate.validate_bulk_mapping_packages_from_folder")
+def test_validate_from_folder_command_with_including_assets_flags(mock_validate,
+                                                                  typer_cli_runner: CliRunner,
+                                                                  tmp_path: Path) -> None:
+    mock_validate.return_value = True
+
+    result = typer_cli_runner.invoke(
+        mssdk_cli_validate_subcommand,
+        ["from-folder", str(tmp_path), "--include-test-data", "--include-output"]
+    )
+
+    assert result.exit_code == 0
+
+    mock_validate.assert_called_once_with(
+        mapping_packages_folder_path=tmp_path,
+        update_hash=False,
+        mapping_package_loader=MappingPackageLoader(include_test_data=True, include_output=True)
     )
 
 
@@ -94,7 +158,6 @@ def test_validate_from_folder_command(mock_validate,
 def test_validate_from_folder_command_with_update_hash(mock_validate,
                                                        typer_cli_runner: CliRunner,
                                                        tmp_path: Path) -> None:
-
     mock_validate.return_value = False
 
     result = typer_cli_runner.invoke(
@@ -106,7 +169,8 @@ def test_validate_from_folder_command_with_update_hash(mock_validate,
 
     mock_validate.assert_called_once_with(
         mapping_packages_folder_path=tmp_path,
-        update_hash=True
+        update_hash=True,
+        mapping_package_loader=MappingPackageLoader(include_test_data=False, include_output=False)
     )
 
 
@@ -115,7 +179,6 @@ def test_validate_from_folder_success_output(mock_validate,
                                              typer_cli_runner: CliRunner,
                                              tmp_path: Path,
                                              caplog) -> None:
-
     mock_validate.return_value = True
 
     result = typer_cli_runner.invoke(


### PR DESCRIPTION
Solves MSSDK1-58

now all validation sub-commands (from-github, from-folder, from-archive) have 2 flags:

1. --include-test-data (Whether to load test data folder or not)                                                                                                                                            
2. --include-output (Whether to load output folder or no)

Now validation without these folders runs faster (locally from 45s to 3s)

Important: validation from-github still works slow because it takes time to fetch this files even if they are not loaded.