### PR TITLE
fix: Solve problem with failing antora because of dublicate nav bars

### DIFF
--- a/docs/antora-playbook.local.yml
+++ b/docs/antora-playbook.local.yml
@@ -7,6 +7,8 @@ content:
   sources:
     - url: ./..
       start_path: docs
+      branches: [HEAD]
+      tags: []
       edit_url: false
 
 ui:

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -7,6 +7,8 @@ content:
   sources:
     - url: https://github.com/meaningfy-ws/mapping-suite-sdk.git
       start_path: docs
+      branches: [main]
+      tags: [ ]
       edit_url: false
 
 ui:


### PR DESCRIPTION
Solve problem of antora failing to build:

{"level":"fatal","time":1756887015718,"name":"antora","hint":"Add the --stacktrace option to see the cause of the error.","msg":"Duplicate nav in ~@mapping-suite-sdk: modules/ROOT/nav.adoc\n    1: docs/modules/ROOT/nav.adoc in https://github.com/meaningfy-ws/mapping-suite-sdk.git (branch: develop | start path: docs)\n    2: docs/modules/ROOT/nav.adoc in https://github.com/meaningfy-ws/mapping-suite-sdk.git (branch: v0.2.1 | start path: docs)"}