### PR TITLE
Add eligibility constraints fields in v1 and v2 model

### DIFF
--- a/mapping_suite_sdk/mapping_package_v1/adapters/mp_v1_loader.py
+++ b/mapping_suite_sdk/mapping_package_v1/adapters/mp_v1_loader.py
@@ -38,7 +38,6 @@ class MappingPackageV1MetadataLoader(MappingPackageAssetLoader):
         model_dict: dict = json.loads(asset_path.read_text())
         model_dict['path'] = asset_path.relative_to(package_folder_path)
         mp_metadata = TypeAdapter(MappingPackageV1Metadata).validate_python(model_dict)
-        mp_metadata.path = asset_path
         return mp_metadata
 
 

--- a/mapping_suite_sdk/mapping_package_v1/models/mapping_package_v1_metadata.py
+++ b/mapping_suite_sdk/mapping_package_v1/models/mapping_package_v1_metadata.py
@@ -9,7 +9,7 @@ from mapping_suite_sdk.core.models.pydantic import PydanticModel
 
 class MappingPackageV1Constraints(PydanticModel):
     """
-
+        A class that defines specific fields of the mapping packages version specific constraints.
     """
 
     eforms_subtype: List[int] = Field(..., description="")
@@ -25,9 +25,9 @@ class MappingPackageV1Constraints(PydanticModel):
 
 class MappingPackageV1EligibilityConstraints(PydanticModel):
     """
-
+        A class that defines constraints field used in metadata.json
     """
-    constraints: MappingPackageV1Constraints = Field(..., description="")
+    constraints: MappingPackageV1Constraints = Field(..., description="Fields with mapping package version specific constraints")
 
 
 class MappingPackageV1Metadata(MappingPackageMetadata):

--- a/mapping_suite_sdk/mapping_package_v1/models/mapping_package_v1_metadata.py
+++ b/mapping_suite_sdk/mapping_package_v1/models/mapping_package_v1_metadata.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List
 
 from pydantic import Field
 
@@ -7,16 +7,27 @@ from mapping_suite_sdk.core.models.mapping_package_metadata import MappingPackag
 from mapping_suite_sdk.core.models.pydantic import PydanticModel
 
 
+class MappingPackageV1Constraints(PydanticModel):
+    """
+
+    """
+
+    eforms_subtype: List[int] = Field(..., description="")
+
+    start_date: List[str] = Field(..., description="")
+
+    end_date: List[str] = Field(..., description="")
+
+    min_xsd_version: List[str] = Field(..., description="")
+
+    max_xsd_version: List[str] = Field(..., description="")
+
+
 class MappingPackageV1EligibilityConstraints(PydanticModel):
     """
-        This shall be a generic dict-like structure as the constraints
-        in the V2 (used in eForms mappings) are different from the
-        constraints in the V1 (used in Standard Forms mappings).
-    """
-    # TODO: For the moment, no concrete structure is provided
-    constraints: dict = Field(default_factory=dict)
 
-    description: Optional[str] = Field(default=None, exclude=True)
+    """
+    constraints: MappingPackageV1Constraints = Field(..., description="")
 
 
 class MappingPackageV1Metadata(MappingPackageMetadata):
@@ -31,6 +42,7 @@ class MappingPackageV1Metadata(MappingPackageMetadata):
     mapping_version: str = Field(..., description="Version of source data that will be mapped", alias="version")
     ontology_version: str = Field(..., description="Version of target ontology")
     description: str = Field(..., description="Metadata description")
+
     eligibility_constraints: MappingPackageV1EligibilityConstraints = Field(...,
                                                                             description="Constraints defining package applicability",
                                                                             alias="metadata_constraints")

--- a/mapping_suite_sdk/mapping_package_v2/adapters/mp_v2_serialiser.py
+++ b/mapping_suite_sdk/mapping_package_v2/adapters/mp_v2_serialiser.py
@@ -18,7 +18,6 @@ class MappingPackageV2MetadataSerialiser(MappingPackageAssetSerialiser):
         metadata_path.parent.mkdir(parents=True, exist_ok=True)
         metadata_path.write_text(asset.model_dump_json(by_alias=True,
                                                        exclude={fields(MappingPackageV2Metadata).path},
-                                                       exclude_none=True,
                                                        # For V2 (eForms)
                                                        indent=4))
 

--- a/mapping_suite_sdk/mapping_package_v2/models/mapping_package_v2_metadata.py
+++ b/mapping_suite_sdk/mapping_package_v2/models/mapping_package_v2_metadata.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import Field
 
@@ -7,15 +7,25 @@ from mapping_suite_sdk.core.models.mapping_package_metadata import MappingPackag
 from mapping_suite_sdk.core.models.pydantic import PydanticModel
 
 
+class MappingPackageV2Constraints(PydanticModel):
+    """
+
+    """
+
+    eforms_subtype: List[str] = Field(..., description="")
+
+    start_date: Optional[List[str]] = Field(..., description="")
+
+    end_date: Optional[List[str]] = Field(..., description="")
+
+    eforms_sdk_versions: List[str] = Field(..., description="")
+
+
 class MappingPackageV2EligibilityConstraints(PydanticModel):
     """
-        This shall be a generic dict-like structure as the constraints
-        in the V2 (eForms) are different from the constraints in the V1 (Standard Forms).
-    """
-    # TODO: For the moment, no concrete structure is provided
-    constraints: dict = Field(default_factory=dict)
 
-    description: Optional[str] = Field(default=None, exclude=True)
+    """
+    constraints: MappingPackageV2Constraints = Field(..., description="")
 
 
 class MappingPackageV2Metadata(MappingPackageMetadata):

--- a/mapping_suite_sdk/mapping_package_v2/models/mapping_package_v2_metadata.py
+++ b/mapping_suite_sdk/mapping_package_v2/models/mapping_package_v2_metadata.py
@@ -9,7 +9,7 @@ from mapping_suite_sdk.core.models.pydantic import PydanticModel
 
 class MappingPackageV2Constraints(PydanticModel):
     """
-
+        A class that defines specific fields of the mapping packages version specific constraints.
     """
 
     eforms_subtype: List[str] = Field(..., description="")
@@ -23,9 +23,9 @@ class MappingPackageV2Constraints(PydanticModel):
 
 class MappingPackageV2EligibilityConstraints(PydanticModel):
     """
-
+        A class that defines constraints field used in metadata.json
     """
-    constraints: MappingPackageV2Constraints = Field(..., description="")
+    constraints: MappingPackageV2Constraints = Field(..., description="Fields with mapping package version specific constraints")
 
 
 class MappingPackageV2Metadata(MappingPackageMetadata):


### PR DESCRIPTION
The problem was that both v1 and v2 metadata classes didn't have constraints fields that will be used in eligibility checking in TED SWS Pipeline.

Solves MSSDK1-69