### PR TITLE
Add one-stop validation service with version auto-detection

### DIFF
--- a/mapping_suite_sdk/tools/services/convert_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/convert_mapping_package.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Union
 
 from mapping_suite_sdk import mssdk_config
+from mapping_suite_sdk.core.adapters.tracer import traced_routine
 from mapping_suite_sdk.core.adapters.version_detector import _resolve_package_root
 from mapping_suite_sdk.mapping_package_v1.adapters.mp_v1_loader import MappingPackageV1Loader
 from mapping_suite_sdk.mapping_package_v1.services.load_mapping_package_v1 import load_mapping_package_v1_from_folder
@@ -64,7 +65,7 @@ class InvalidPackagePathError(ConversionError):
     """Raised when package path is invalid."""
     pass
 
-
+@traced_routine
 def load_mapping_package_from_folder(from_version: str, mapping_package_folder_path: Path):
     """
     Load a mapping package from filesystem based on version.
@@ -106,7 +107,7 @@ def load_mapping_package_from_folder(from_version: str, mapping_package_folder_p
     else:
         raise UnsupportedVersionError(f"Unsupported source version: {from_version}")
 
-
+@traced_routine
 def convert_mapping_package_model(from_version: str, to_version: str, source_package):
     """
     Convert mapping package model between versions.
@@ -263,7 +264,7 @@ def _remove_folder(mapping_package_folder_path: Path, relative_folder_path: Unio
             package_source=mapping_package_folder_path,
             message=f"Removed {folder_name} folder from {folder_path}"))
 
-
+@traced_routine
 def serialise_mapping_package(to_version: str, mapping_package_folder_path: Path, converted_package) -> None:
     """
     Serialize a mapping package to filesystem based on version.
@@ -303,7 +304,7 @@ def serialise_mapping_package(to_version: str, mapping_package_folder_path: Path
     else:
         raise UnsupportedVersionError(f"Unsupported target version: {to_version}")
 
-
+@traced_routine
 def convert_mapping_package_from_folder(
     from_version: str,
     to_version: str,
@@ -333,7 +334,7 @@ def convert_mapping_package_from_folder(
     converted_package = convert_mapping_package_model(from_version, to_version, source_package)
     serialise_mapping_package(to_version, mapping_package_folder_path, converted_package)
 
-
+@traced_routine
 def convert_mapping_packages_from_folder(
     from_version: str,
     to_version: str,

--- a/mapping_suite_sdk/tools/services/validate_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/validate_mapping_package.py
@@ -1,0 +1,154 @@
+"""
+Cross-version validation service for mapping packages.
+
+This module provides a single public `validate_mapping_package(...)` function that:
+- validates a mapping package model instance, OR a folder/archive path
+- auto-detects the mapping package version only when `version` is not provided
+- dispatches to the appropriate version-specific validator
+
+Consumers should not need to import version-specific validation modules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+from typing import Optional, Union, Literal, NoReturn, Any
+
+from mapping_suite_sdk.core.adapters.extractor import ArchiveExtractor
+from mapping_suite_sdk.core.adapters.validator import MPValidationException, MPValidationStepABC
+from mapping_suite_sdk.core.adapters.version_detector import detect_mapping_package_version
+
+
+class CrossVersionValidationError(MPValidationException):
+    """Raised when cross-version validation cannot route to a validator."""
+
+
+def _normalize_version(version: str) -> str:
+    v = version.strip()
+    if v.lower() == "v3l":
+        return "v3L"
+    return v.lower()
+
+
+def _validate_model(mapping_package: Any, version: str) -> Literal[True] | NoReturn:
+    # Import lazily to avoid version-specific imports in consumer code.
+    from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1 import MappingPackageV1
+    from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2 import MappingPackageV2
+    from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3 import MappingPackageV3
+    from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3_lightweight import MappingPackageV3Lightweight
+
+    from mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1 import validate_mapping_package_v1
+    from mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2 import validate_mapping_package_v2
+    from mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3 import validate_mapping_package_v3
+    from mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight import (
+        validate_mapping_package_v3_lightweight,
+    )
+
+    if version == "v1":
+        if not isinstance(mapping_package, MappingPackageV1):
+            raise CrossVersionValidationError(f"Version 'v1' requires MappingPackageV1, got: {type(mapping_package)}")
+        return validate_mapping_package_v1(mapping_package=mapping_package)
+    if version == "v2":
+        if not isinstance(mapping_package, MappingPackageV2):
+            raise CrossVersionValidationError(f"Version 'v2' requires MappingPackageV2, got: {type(mapping_package)}")
+        return validate_mapping_package_v2(mapping_package=mapping_package)
+    if version == "v3":
+        if not isinstance(mapping_package, MappingPackageV3):
+            raise CrossVersionValidationError(f"Version 'v3' requires MappingPackageV3, got: {type(mapping_package)}")
+        return validate_mapping_package_v3(mapping_package=mapping_package)
+    if version == "v3L":
+        if not isinstance(mapping_package, MappingPackageV3Lightweight):
+            raise CrossVersionValidationError(
+                f"Version 'v3L' requires MappingPackageV3Lightweight, got: {type(mapping_package)}"
+            )
+        return validate_mapping_package_v3_lightweight(mapping_package=mapping_package)
+
+    raise CrossVersionValidationError(f"Unsupported version: {version}")
+
+
+def _validate_folder(mapping_package_folder_path: Path, version: str) -> Literal[True] | NoReturn:
+    from mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1 import validate_mapping_package_v1_from_folder
+    from mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2 import validate_mapping_package_v2_from_folder
+    from mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3 import validate_mapping_package_v3_from_folder
+    from mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight import (
+        validate_mapping_package_v3_lightweight_from_folder,
+    )
+
+    if version == "v1":
+        return validate_mapping_package_v1_from_folder(mapping_package_folder_path=mapping_package_folder_path)
+    if version == "v2":
+        return validate_mapping_package_v2_from_folder(mapping_package_folder_path=mapping_package_folder_path)
+    if version == "v3":
+        return validate_mapping_package_v3_from_folder(mapping_package_folder_path=mapping_package_folder_path)
+    if version == "v3L":
+        return validate_mapping_package_v3_lightweight_from_folder(mapping_package_folder_path=mapping_package_folder_path)
+
+    raise CrossVersionValidationError(f"Unsupported version: {version}")
+
+
+def validate_mapping_package(
+    mapping_package: Union[Path, object],
+    *,
+    version: Optional[str] = None,
+) -> Literal[True] | NoReturn:
+    """
+    Validate a mapping package using version-specific logic, with optional auto-detection.
+
+    - If `version` is provided, no auto-detection is performed.
+    - If `version` is not provided, the version is auto-detected:
+      - for `Path`: via `detect_mapping_package_version(path)` (folder), or via temp extraction (archive)
+      - for model instances: via `isinstance(...)` checks
+
+    Args:
+        mapping_package: Either a mapping package model instance or a folder/archive path.
+        version: Optional explicit version ("v1", "v2", "v3", "v3L"). When provided, version detection is skipped.
+
+    Returns:
+        True if validation passes, otherwise raises.
+    """
+    if isinstance(mapping_package, Path):
+        path = mapping_package
+        # Validate basic path shape early with consistent errors
+        MPValidationStepABC.validate_path_exists(path, context="validate mapping package")
+
+        if path.is_file():
+            MPValidationStepABC.validate_archive_path(path, context="validate mapping package archive")
+            extractor = ArchiveExtractor()
+            # IMPORTANT: don't use extract_temporary() here because it wraps any exception raised
+            # inside the context (including validation failures) as a ZIP extraction failure.
+            with tempfile.TemporaryDirectory() as temp_dir:
+                extracted_folder = extractor.extract(path, Path(temp_dir))
+
+                detected = _normalize_version(version) if version else detect_mapping_package_version(extracted_folder)
+                if not detected:
+                    raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
+                return _validate_folder(extracted_folder, detected)
+
+        MPValidationStepABC.validate_folder_path(path, context="validate mapping package folder")
+        detected = _normalize_version(version) if version else detect_mapping_package_version(path)
+        if not detected:
+            raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
+        return _validate_folder(path, detected)
+
+    # Model instance case
+    if version is not None:
+        return _validate_model(mapping_package, _normalize_version(version))
+
+    # Auto-detect from model type (no filesystem detection).
+    from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1 import MappingPackageV1
+    from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2 import MappingPackageV2
+    from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3 import MappingPackageV3
+    from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3_lightweight import MappingPackageV3Lightweight
+
+    if isinstance(mapping_package, MappingPackageV1):
+        return _validate_model(mapping_package, "v1")
+    if isinstance(mapping_package, MappingPackageV2):
+        return _validate_model(mapping_package, "v2")
+    if isinstance(mapping_package, MappingPackageV3Lightweight):
+        return _validate_model(mapping_package, "v3L")
+    if isinstance(mapping_package, MappingPackageV3):
+        return _validate_model(mapping_package, "v3")
+
+    raise CrossVersionValidationError(f"Cannot auto-detect version from mapping package type: {type(mapping_package)}")
+

--- a/mapping_suite_sdk/tools/services/validate_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/validate_mapping_package.py
@@ -16,11 +16,13 @@ import tempfile
 from typing import Optional, Union, Literal, NoReturn, Any
 
 from mapping_suite_sdk.core.adapters.extractor import ArchiveExtractor
+from mapping_suite_sdk.core.adapters.tracer import traced_class, traced_routine
 from mapping_suite_sdk.core.adapters.validator import MPValidationException, MPValidationStepABC
 from mapping_suite_sdk.core.adapters.version_detector import detect_mapping_package_version
 from mapping_suite_sdk.tools.services.convert_mapping_package import Version
 
 
+@traced_class
 class CrossVersionValidationError(MPValidationException):
     """Raised when cross-version validation cannot route to a validator."""
 
@@ -111,7 +113,7 @@ def _validate_folder(mapping_package_folder_path: Path, version: Version) -> Lit
 
     raise CrossVersionValidationError(f"Unsupported version: {version}")
 
-
+@traced_routine
 def validate_mapping_package(
     mapping_package: Union[Path, object],
     *,
@@ -176,4 +178,3 @@ def validate_mapping_package(
         return _validate_model(mapping_package, Version.V3)
 
     raise CrossVersionValidationError(f"Cannot auto-detect version from mapping package type: {type(mapping_package)}")
-

--- a/mapping_suite_sdk/tools/services/validate_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/validate_mapping_package.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 
 from pathlib import Path
 import tempfile
-from typing import Optional, Union, Literal, NoReturn, Any
+from typing import Optional, Literal, NoReturn
 
 from mapping_suite_sdk.core.adapters.extractor import ArchiveExtractor
 from mapping_suite_sdk.core.adapters.tracer import traced_class, traced_routine
 from mapping_suite_sdk.core.adapters.validator import MPValidationException, MPValidationStepABC
 from mapping_suite_sdk.core.adapters.version_detector import detect_mapping_package_version
+from mapping_suite_sdk.core.models.mapping_package import MappingPackage
 from mapping_suite_sdk.tools.services.convert_mapping_package import Version
 
 
@@ -58,7 +59,7 @@ def _normalize_version(version: str) -> Version:
     return version_map[normalized]
 
 
-def _validate_model(mapping_package: Any, version: Version) -> Literal[True] | NoReturn:
+def _validate_model(mapping_package: MappingPackage, version: Version) -> Literal[True] | NoReturn:
     # Import lazily to avoid version-specific imports in consumer code.
     from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1 import MappingPackageV1
     from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2 import MappingPackageV2
@@ -115,8 +116,7 @@ def _validate_folder(mapping_package_folder_path: Path, version: Version) -> Lit
 
 @traced_routine
 def validate_mapping_package(
-    mapping_package: Union[Path, object],
-    *,
+    mapping_package: Path | MappingPackage,
     version: Optional[str] = None,
 ) -> Literal[True] | NoReturn:
     """
@@ -139,6 +139,7 @@ def validate_mapping_package(
         # Validate basic path shape early with consistent errors
         MPValidationStepABC.validate_path_exists(path, context="validate mapping package")
 
+        # if the given path is a file, assume it as a (ZIP) archive
         if path.is_file():
             MPValidationStepABC.validate_archive_path(path, context="validate mapping package archive")
             extractor = ArchiveExtractor()
@@ -152,6 +153,7 @@ def validate_mapping_package(
                     raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
                 return _validate_folder(extracted_folder, detected)
 
+        # if not a file, assume it's a folder
         MPValidationStepABC.validate_folder_path(path, context="validate mapping package folder")
         detected = _normalize_version(version) if version else detect_mapping_package_version(path)
         if not detected:

--- a/mapping_suite_sdk/tools/services/validate_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/validate_mapping_package.py
@@ -18,20 +18,45 @@ from typing import Optional, Union, Literal, NoReturn, Any
 from mapping_suite_sdk.core.adapters.extractor import ArchiveExtractor
 from mapping_suite_sdk.core.adapters.validator import MPValidationException, MPValidationStepABC
 from mapping_suite_sdk.core.adapters.version_detector import detect_mapping_package_version
+from mapping_suite_sdk.tools.services.convert_mapping_package import Version
 
 
 class CrossVersionValidationError(MPValidationException):
     """Raised when cross-version validation cannot route to a validator."""
 
 
-def _normalize_version(version: str) -> str:
-    v = version.strip()
-    if v.lower() == "v3l":
-        return "v3L"
-    return v.lower()
+def _normalize_version(version: str) -> Version:
+    """
+    Normalize version string input to a Version enum member.
+
+    Handles case-insensitive input and whitespace trimming.
+
+    Args:
+        version: Version string (e.g., "V1", "  v3L  ", "V2")
+
+    Returns:
+        Version enum member
+
+    Raises:
+        CrossVersionValidationError: If version is not supported
+    """
+    normalized = version.strip().lower()
+
+    # Map lowercase input to Version enum
+    version_map = {
+        "v1": Version.V1,
+        "v2": Version.V2,
+        "v3": Version.V3,
+        "v3l": Version.V3L,
+    }
+
+    if normalized not in version_map:
+        raise CrossVersionValidationError(f"Unsupported version: {version}")
+
+    return version_map[normalized]
 
 
-def _validate_model(mapping_package: Any, version: str) -> Literal[True] | NoReturn:
+def _validate_model(mapping_package: Any, version: Version) -> Literal[True] | NoReturn:
     # Import lazily to avoid version-specific imports in consumer code.
     from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1 import MappingPackageV1
     from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2 import MappingPackageV2
@@ -45,19 +70,19 @@ def _validate_model(mapping_package: Any, version: str) -> Literal[True] | NoRet
         validate_mapping_package_v3_lightweight,
     )
 
-    if version == "v1":
+    if version == Version.V1:
         if not isinstance(mapping_package, MappingPackageV1):
             raise CrossVersionValidationError(f"Version 'v1' requires MappingPackageV1, got: {type(mapping_package)}")
         return validate_mapping_package_v1(mapping_package=mapping_package)
-    if version == "v2":
+    if version == Version.V2:
         if not isinstance(mapping_package, MappingPackageV2):
             raise CrossVersionValidationError(f"Version 'v2' requires MappingPackageV2, got: {type(mapping_package)}")
         return validate_mapping_package_v2(mapping_package=mapping_package)
-    if version == "v3":
+    if version == Version.V3:
         if not isinstance(mapping_package, MappingPackageV3):
             raise CrossVersionValidationError(f"Version 'v3' requires MappingPackageV3, got: {type(mapping_package)}")
         return validate_mapping_package_v3(mapping_package=mapping_package)
-    if version == "v3L":
+    if version == Version.V3L:
         if not isinstance(mapping_package, MappingPackageV3Lightweight):
             raise CrossVersionValidationError(
                 f"Version 'v3L' requires MappingPackageV3Lightweight, got: {type(mapping_package)}"
@@ -67,7 +92,7 @@ def _validate_model(mapping_package: Any, version: str) -> Literal[True] | NoRet
     raise CrossVersionValidationError(f"Unsupported version: {version}")
 
 
-def _validate_folder(mapping_package_folder_path: Path, version: str) -> Literal[True] | NoReturn:
+def _validate_folder(mapping_package_folder_path: Path, version: Version) -> Literal[True] | NoReturn:
     from mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1 import validate_mapping_package_v1_from_folder
     from mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2 import validate_mapping_package_v2_from_folder
     from mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3 import validate_mapping_package_v3_from_folder
@@ -75,13 +100,13 @@ def _validate_folder(mapping_package_folder_path: Path, version: str) -> Literal
         validate_mapping_package_v3_lightweight_from_folder,
     )
 
-    if version == "v1":
+    if version == Version.V1:
         return validate_mapping_package_v1_from_folder(mapping_package_folder_path=mapping_package_folder_path)
-    if version == "v2":
+    if version == Version.V2:
         return validate_mapping_package_v2_from_folder(mapping_package_folder_path=mapping_package_folder_path)
-    if version == "v3":
+    if version == Version.V3:
         return validate_mapping_package_v3_from_folder(mapping_package_folder_path=mapping_package_folder_path)
-    if version == "v3L":
+    if version == Version.V3L:
         return validate_mapping_package_v3_lightweight_from_folder(mapping_package_folder_path=mapping_package_folder_path)
 
     raise CrossVersionValidationError(f"Unsupported version: {version}")
@@ -142,13 +167,13 @@ def validate_mapping_package(
     from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3_lightweight import MappingPackageV3Lightweight
 
     if isinstance(mapping_package, MappingPackageV1):
-        return _validate_model(mapping_package, "v1")
+        return _validate_model(mapping_package, Version.V1)
     if isinstance(mapping_package, MappingPackageV2):
-        return _validate_model(mapping_package, "v2")
+        return _validate_model(mapping_package, Version.V2)
     if isinstance(mapping_package, MappingPackageV3Lightweight):
-        return _validate_model(mapping_package, "v3L")
+        return _validate_model(mapping_package, Version.V3L)
     if isinstance(mapping_package, MappingPackageV3):
-        return _validate_model(mapping_package, "v3")
+        return _validate_model(mapping_package, Version.V3)
 
     raise CrossVersionValidationError(f"Cannot auto-detect version from mapping package type: {type(mapping_package)}")
 

--- a/mapping_suite_sdk/tools/services/validate_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/validate_mapping_package.py
@@ -95,7 +95,8 @@ def _validate_model(mapping_package: MappingPackage, version: Version) -> Litera
     raise CrossVersionValidationError(f"Unsupported version: {version}")
 
 
-def _validate_folder(mapping_package_folder_path: Path, version: Version) -> Literal[True] | NoReturn:
+def _validate_folder_from_path(path: Path, version: Version) -> Literal[True] | NoReturn:
+    """Call the appropriate version-specific folder validator."""
     from mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1 import validate_mapping_package_v1_from_folder
     from mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2 import validate_mapping_package_v2_from_folder
     from mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3 import validate_mapping_package_v3_from_folder
@@ -104,15 +105,67 @@ def _validate_folder(mapping_package_folder_path: Path, version: Version) -> Lit
     )
 
     if version == Version.V1:
-        return validate_mapping_package_v1_from_folder(mapping_package_folder_path=mapping_package_folder_path)
+        return validate_mapping_package_v1_from_folder(mapping_package_folder_path=path)
     if version == Version.V2:
-        return validate_mapping_package_v2_from_folder(mapping_package_folder_path=mapping_package_folder_path)
+        return validate_mapping_package_v2_from_folder(mapping_package_folder_path=path)
     if version == Version.V3:
-        return validate_mapping_package_v3_from_folder(mapping_package_folder_path=mapping_package_folder_path)
+        return validate_mapping_package_v3_from_folder(mapping_package_folder_path=path)
     if version == Version.V3L:
-        return validate_mapping_package_v3_lightweight_from_folder(mapping_package_folder_path=mapping_package_folder_path)
+        return validate_mapping_package_v3_lightweight_from_folder(mapping_package_folder_path=path)
 
     raise CrossVersionValidationError(f"Unsupported version: {version}")
+
+
+def _validate_archive_path(path: Path, version: Optional[str]) -> Literal[True] | NoReturn:
+    """Validate a mapping package from an archive file."""
+    MPValidationStepABC.validate_archive_path(path, context="validate mapping package archive")
+    extractor = ArchiveExtractor()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        extracted_folder = extractor.extract(path, Path(temp_dir))
+
+        detected = _normalize_version(version) if version else detect_mapping_package_version(extracted_folder)
+        if not detected:
+            raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
+        return _validate_folder_from_path(extracted_folder, detected)
+
+
+def _validate_folder_path(path: Path, version: Optional[str]) -> Literal[True] | NoReturn:
+    """Validate a mapping package from a folder path."""
+    MPValidationStepABC.validate_folder_path(path, context="validate mapping package folder")
+    detected = _normalize_version(version) if version else detect_mapping_package_version(path)
+    if not detected:
+        raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
+    return _validate_folder_from_path(path, detected)
+
+
+def _validate_path(path: Path, version: Optional[str]) -> Literal[True] | NoReturn:
+    """Validate a mapping package from a Path (file or folder)."""
+    MPValidationStepABC.validate_path_exists(path, context="validate mapping package")
+
+    if path.is_file():
+        return _validate_archive_path(path, version)
+    
+    return _validate_folder_path(path, version)
+
+
+def _detect_version_from_model(mapping_package: MappingPackage) -> Version:
+    """Auto-detect version from model instance type."""
+    from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1 import MappingPackageV1
+    from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2 import MappingPackageV2
+    from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3 import MappingPackageV3
+    from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3_lightweight import MappingPackageV3Lightweight
+
+    if isinstance(mapping_package, MappingPackageV1):
+        return Version.V1
+    if isinstance(mapping_package, MappingPackageV2):
+        return Version.V2
+    if isinstance(mapping_package, MappingPackageV3Lightweight):
+        return Version.V3L
+    if isinstance(mapping_package, MappingPackageV3):
+        return Version.V3
+
+    raise CrossVersionValidationError(f"Cannot auto-detect version from mapping package type: {type(mapping_package)}")
+
 
 @traced_routine
 def validate_mapping_package(
@@ -135,48 +188,8 @@ def validate_mapping_package(
         True if validation passes, otherwise raises.
     """
     if isinstance(mapping_package, Path):
-        path = mapping_package
-        # Validate basic path shape early with consistent errors
-        MPValidationStepABC.validate_path_exists(path, context="validate mapping package")
-
-        # if the given path is a file, assume it as a (ZIP) archive
-        if path.is_file():
-            MPValidationStepABC.validate_archive_path(path, context="validate mapping package archive")
-            extractor = ArchiveExtractor()
-            # IMPORTANT: don't use extract_temporary() here because it wraps any exception raised
-            # inside the context (including validation failures) as a ZIP extraction failure.
-            with tempfile.TemporaryDirectory() as temp_dir:
-                extracted_folder = extractor.extract(path, Path(temp_dir))
-
-                detected = _normalize_version(version) if version else detect_mapping_package_version(extracted_folder)
-                if not detected:
-                    raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
-                return _validate_folder(extracted_folder, detected)
-
-        # if not a file, assume it's a folder
-        MPValidationStepABC.validate_folder_path(path, context="validate mapping package folder")
-        detected = _normalize_version(version) if version else detect_mapping_package_version(path)
-        if not detected:
-            raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
-        return _validate_folder(path, detected)
+        return _validate_path(mapping_package, version)
 
     # Model instance case
-    if version is not None:
-        return _validate_model(mapping_package, _normalize_version(version))
-
-    # Auto-detect from model type (no filesystem detection).
-    from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1 import MappingPackageV1
-    from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2 import MappingPackageV2
-    from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3 import MappingPackageV3
-    from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3_lightweight import MappingPackageV3Lightweight
-
-    if isinstance(mapping_package, MappingPackageV1):
-        return _validate_model(mapping_package, Version.V1)
-    if isinstance(mapping_package, MappingPackageV2):
-        return _validate_model(mapping_package, Version.V2)
-    if isinstance(mapping_package, MappingPackageV3Lightweight):
-        return _validate_model(mapping_package, Version.V3L)
-    if isinstance(mapping_package, MappingPackageV3):
-        return _validate_model(mapping_package, Version.V3)
-
-    raise CrossVersionValidationError(f"Cannot auto-detect version from mapping package type: {type(mapping_package)}")
+    detected = _normalize_version(version) if version else _detect_version_from_model(mapping_package)
+    return _validate_model(mapping_package, detected)

--- a/tests/unit/tools/services/test_validate_mapping_package.py
+++ b/tests/unit/tools/services/test_validate_mapping_package.py
@@ -4,21 +4,23 @@ from unittest.mock import patch
 import pytest
 
 from mapping_suite_sdk.core.adapters.validator import MPValidationException
+from mapping_suite_sdk.tools.services.convert_mapping_package import Version
 from mapping_suite_sdk.tools.services.convert_mapping_package_v3_to_v3_lightweight import (
     convert_mapping_package_v3_to_v3_lightweight,
 )
 from mapping_suite_sdk.tools.services.validate_mapping_package import (
     CrossVersionValidationError,
     _normalize_version,
-    _validate_folder,
+    _validate_folder_from_path,
     _validate_model,
+    _detect_version_from_model,
     validate_mapping_package,
 )
 
 
 def test_validate_mapping_package_auto_detects_version_for_folder_path(tmp_path: Path) -> None:
     with (
-        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version", return_value="v2") as mock_detect,
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version", return_value=Version.V2) as mock_detect,
         patch("mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2_from_folder", return_value=True) as mock_v2,
     ):
         assert validate_mapping_package(tmp_path) is True
@@ -50,7 +52,7 @@ def test_validate_mapping_package_archive_does_not_wrap_validation_errors(tmp_pa
 
     with (
         patch("mapping_suite_sdk.tools.services.validate_mapping_package.ArchiveExtractor.extract", return_value=tmp_path / "extracted") as mock_extract,
-        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version", return_value="v3L"),
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version", return_value=Version.V3L),
         patch(
             "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight.validate_mapping_package_v3_lightweight_from_folder",
             side_effect=MPValidationException("Hash validation failed"),
@@ -85,19 +87,24 @@ def test_validate_mapping_package_explicit_version_skips_detection_for_model(fix
 
 
 def test_normalize_version_strips_whitespace() -> None:
-    assert _normalize_version("  v1  ") == "v1"
+    assert _normalize_version("  v1  ") == Version.V1
 
 
 def test_normalize_version_lowercases() -> None:
-    assert _normalize_version("V1") == "v1"
-    assert _normalize_version("V2") == "v2"
-    assert _normalize_version("V3") == "v3"
+    assert _normalize_version("V1") == Version.V1
+    assert _normalize_version("V2") == Version.V2
+    assert _normalize_version("V3") == Version.V3
 
 
 def test_normalize_version_v3l_to_v3L() -> None:
-    assert _normalize_version("v3l") == "v3L"
-    assert _normalize_version("V3L") == "v3L"
-    assert _normalize_version("  v3l  ") == "v3L"
+    assert _normalize_version("v3l") == Version.V3L
+    assert _normalize_version("V3L") == Version.V3L
+    assert _normalize_version("  v3l  ") == Version.V3L
+
+
+def test_normalize_version_raises_on_invalid_version() -> None:
+    with pytest.raises(CrossVersionValidationError, match="Unsupported version: v99"):
+        _normalize_version("v99")
 
 
 # --- _validate_model ---
@@ -108,13 +115,13 @@ def test_validate_model_v1_calls_v1_validator(dummy_mapping_package_v1_model) ->
         "mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1.validate_mapping_package_v1",
         return_value=True,
     ) as mock_v1:
-        assert _validate_model(dummy_mapping_package_v1_model, "v1") is True
+        assert _validate_model(dummy_mapping_package_v1_model, Version.V1) is True
         mock_v1.assert_called_once_with(mapping_package=dummy_mapping_package_v1_model)
 
 
 def test_validate_model_v1_raises_on_wrong_type(fixture_mapping_package_v3_model) -> None:
     with pytest.raises(CrossVersionValidationError, match="Version 'v1' requires MappingPackageV1"):
-        _validate_model(fixture_mapping_package_v3_model, "v1")
+        _validate_model(fixture_mapping_package_v3_model, Version.V1)
 
 
 def test_validate_model_v2_calls_v2_validator(dummy_mapping_package_v2_model) -> None:
@@ -122,13 +129,13 @@ def test_validate_model_v2_calls_v2_validator(dummy_mapping_package_v2_model) ->
         "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2",
         return_value=True,
     ) as mock_v2:
-        assert _validate_model(dummy_mapping_package_v2_model, "v2") is True
+        assert _validate_model(dummy_mapping_package_v2_model, Version.V2) is True
         mock_v2.assert_called_once_with(mapping_package=dummy_mapping_package_v2_model)
 
 
 def test_validate_model_v2_raises_on_wrong_type(dummy_mapping_package_v1_model) -> None:
     with pytest.raises(CrossVersionValidationError, match="Version 'v2' requires MappingPackageV2"):
-        _validate_model(dummy_mapping_package_v1_model, "v2")
+        _validate_model(dummy_mapping_package_v1_model, Version.V2)
 
 
 def test_validate_model_v3_calls_v3_validator(fixture_mapping_package_v3_model) -> None:
@@ -136,13 +143,13 @@ def test_validate_model_v3_calls_v3_validator(fixture_mapping_package_v3_model) 
         "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3",
         return_value=True,
     ) as mock_v3:
-        assert _validate_model(fixture_mapping_package_v3_model, "v3") is True
+        assert _validate_model(fixture_mapping_package_v3_model, Version.V3) is True
         mock_v3.assert_called_once_with(mapping_package=fixture_mapping_package_v3_model)
 
 
 def test_validate_model_v3_raises_on_wrong_type(dummy_mapping_package_v1_model) -> None:
     with pytest.raises(CrossVersionValidationError, match="Version 'v3' requires MappingPackageV3"):
-        _validate_model(dummy_mapping_package_v1_model, "v3")
+        _validate_model(dummy_mapping_package_v1_model, Version.V3)
 
 
 def test_validate_model_v3L_calls_v3_lightweight_validator(
@@ -153,7 +160,7 @@ def test_validate_model_v3L_calls_v3_lightweight_validator(
         "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight.validate_mapping_package_v3_lightweight",
         return_value=True,
     ) as mock_v3l:
-        assert _validate_model(v3l_model, "v3L") is True
+        assert _validate_model(v3l_model, Version.V3L) is True
         mock_v3l.assert_called_once_with(mapping_package=v3l_model)
 
 
@@ -162,56 +169,71 @@ def test_validate_model_v3L_raises_on_wrong_type(fixture_mapping_package_v3_mode
         CrossVersionValidationError,
         match="Version 'v3L' requires MappingPackageV3Lightweight",
     ):
-        _validate_model(fixture_mapping_package_v3_model, "v3L")
+        _validate_model(fixture_mapping_package_v3_model, Version.V3L)
 
 
-def test_validate_model_raises_on_unsupported_version(dummy_mapping_package_v1_model) -> None:
-    with pytest.raises(CrossVersionValidationError, match="Unsupported version: v99"):
-        _validate_model(dummy_mapping_package_v1_model, "v99")
+# --- _validate_folder_from_path ---
 
 
-# --- _validate_folder ---
-
-
-def test_validate_folder_v1_calls_v1_from_folder(tmp_path: Path) -> None:
+def test_validate_folder_from_path_v1_calls_v1_from_folder(tmp_path: Path) -> None:
     with patch(
         "mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1.validate_mapping_package_v1_from_folder",
         return_value=True,
     ) as mock_v1:
-        assert _validate_folder(tmp_path, "v1") is True
+        assert _validate_folder_from_path(tmp_path, Version.V1) is True
         mock_v1.assert_called_once_with(mapping_package_folder_path=tmp_path)
 
 
-def test_validate_folder_v2_calls_v2_from_folder(tmp_path: Path) -> None:
+def test_validate_folder_from_path_v2_calls_v2_from_folder(tmp_path: Path) -> None:
     with patch(
         "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2_from_folder",
         return_value=True,
     ) as mock_v2:
-        assert _validate_folder(tmp_path, "v2") is True
+        assert _validate_folder_from_path(tmp_path, Version.V2) is True
         mock_v2.assert_called_once_with(mapping_package_folder_path=tmp_path)
 
 
-def test_validate_folder_v3_calls_v3_from_folder(tmp_path: Path) -> None:
+def test_validate_folder_from_path_v3_calls_v3_from_folder(tmp_path: Path) -> None:
     with patch(
         "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3_from_folder",
         return_value=True,
     ) as mock_v3:
-        assert _validate_folder(tmp_path, "v3") is True
+        assert _validate_folder_from_path(tmp_path, Version.V3) is True
         mock_v3.assert_called_once_with(mapping_package_folder_path=tmp_path)
 
 
-def test_validate_folder_v3L_calls_v3_lightweight_from_folder(tmp_path: Path) -> None:
+def test_validate_folder_from_path_v3L_calls_v3_lightweight_from_folder(tmp_path: Path) -> None:
     with patch(
         "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight.validate_mapping_package_v3_lightweight_from_folder",
         return_value=True,
     ) as mock_v3l:
-        assert _validate_folder(tmp_path, "v3L") is True
+        assert _validate_folder_from_path(tmp_path, Version.V3L) is True
         mock_v3l.assert_called_once_with(mapping_package_folder_path=tmp_path)
 
 
-def test_validate_folder_raises_on_unsupported_version(tmp_path: Path) -> None:
-    with pytest.raises(CrossVersionValidationError, match="Unsupported version: v99"):
-        _validate_folder(tmp_path, "v99")
+# --- _detect_version_from_model ---
+
+
+def test_detect_version_from_model_v1(dummy_mapping_package_v1_model) -> None:
+    assert _detect_version_from_model(dummy_mapping_package_v1_model) == Version.V1
+
+
+def test_detect_version_from_model_v2(dummy_mapping_package_v2_model) -> None:
+    assert _detect_version_from_model(dummy_mapping_package_v2_model) == Version.V2
+
+
+def test_detect_version_from_model_v3(fixture_mapping_package_v3_model) -> None:
+    assert _detect_version_from_model(fixture_mapping_package_v3_model) == Version.V3
+
+
+def test_detect_version_from_model_v3L(fixture_mapping_package_v3_model) -> None:
+    v3l_model = convert_mapping_package_v3_to_v3_lightweight(fixture_mapping_package_v3_model)
+    assert _detect_version_from_model(v3l_model) == Version.V3L
+
+
+def test_detect_version_from_model_raises_for_unknown_type() -> None:
+    with pytest.raises(CrossVersionValidationError, match="Cannot auto-detect version"):
+        _detect_version_from_model("not a package")
 
 
 # --- validate_mapping_package: archive + unknown version ---
@@ -286,4 +308,3 @@ def test_validate_mapping_package_raises_when_model_type_unknown() -> None:
         match="Cannot auto-detect version from mapping package type",
     ):
         validate_mapping_package("not a package")
-

--- a/tests/unit/tools/services/test_validate_mapping_package.py
+++ b/tests/unit/tools/services/test_validate_mapping_package.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from typing import cast
 
 from mapping_suite_sdk.core.adapters.validator import MPValidationException
 from mapping_suite_sdk.tools.services.convert_mapping_package import Version
@@ -170,6 +171,11 @@ def test_validate_model_v3L_raises_on_wrong_type(fixture_mapping_package_v3_mode
         match="Version 'v3L' requires MappingPackageV3Lightweight",
     ):
         _validate_model(fixture_mapping_package_v3_model, Version.V3L)
+
+
+def test_validate_model_raises_on_unsupported_version(dummy_mapping_package_v1_model) -> None:
+    with pytest.raises(CrossVersionValidationError, match="Unsupported version"):
+        _validate_model(dummy_mapping_package_v1_model, cast(Version, "v99"))
 
 
 # --- _validate_folder_from_path ---

--- a/tests/unit/tools/services/test_validate_mapping_package.py
+++ b/tests/unit/tools/services/test_validate_mapping_package.py
@@ -4,8 +4,14 @@ from unittest.mock import patch
 import pytest
 
 from mapping_suite_sdk.core.adapters.validator import MPValidationException
+from mapping_suite_sdk.tools.services.convert_mapping_package_v3_to_v3_lightweight import (
+    convert_mapping_package_v3_to_v3_lightweight,
+)
 from mapping_suite_sdk.tools.services.validate_mapping_package import (
     CrossVersionValidationError,
+    _normalize_version,
+    _validate_folder,
+    _validate_model,
     validate_mapping_package,
 )
 
@@ -73,4 +79,211 @@ def test_validate_mapping_package_explicit_version_skips_detection_for_model(fix
         assert validate_mapping_package(fixture_mapping_package_v3_model, version="v3") is True
         mock_detect.assert_not_called()
         mock_v3.assert_called_once()
+
+
+# --- _normalize_version ---
+
+
+def test_normalize_version_strips_whitespace() -> None:
+    assert _normalize_version("  v1  ") == "v1"
+
+
+def test_normalize_version_lowercases() -> None:
+    assert _normalize_version("V1") == "v1"
+    assert _normalize_version("V2") == "v2"
+    assert _normalize_version("V3") == "v3"
+
+
+def test_normalize_version_v3l_to_v3L() -> None:
+    assert _normalize_version("v3l") == "v3L"
+    assert _normalize_version("V3L") == "v3L"
+    assert _normalize_version("  v3l  ") == "v3L"
+
+
+# --- _validate_model ---
+
+
+def test_validate_model_v1_calls_v1_validator(dummy_mapping_package_v1_model) -> None:
+    with patch(
+        "mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1.validate_mapping_package_v1",
+        return_value=True,
+    ) as mock_v1:
+        assert _validate_model(dummy_mapping_package_v1_model, "v1") is True
+        mock_v1.assert_called_once_with(mapping_package=dummy_mapping_package_v1_model)
+
+
+def test_validate_model_v1_raises_on_wrong_type(fixture_mapping_package_v3_model) -> None:
+    with pytest.raises(CrossVersionValidationError, match="Version 'v1' requires MappingPackageV1"):
+        _validate_model(fixture_mapping_package_v3_model, "v1")
+
+
+def test_validate_model_v2_calls_v2_validator(dummy_mapping_package_v2_model) -> None:
+    with patch(
+        "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2",
+        return_value=True,
+    ) as mock_v2:
+        assert _validate_model(dummy_mapping_package_v2_model, "v2") is True
+        mock_v2.assert_called_once_with(mapping_package=dummy_mapping_package_v2_model)
+
+
+def test_validate_model_v2_raises_on_wrong_type(dummy_mapping_package_v1_model) -> None:
+    with pytest.raises(CrossVersionValidationError, match="Version 'v2' requires MappingPackageV2"):
+        _validate_model(dummy_mapping_package_v1_model, "v2")
+
+
+def test_validate_model_v3_calls_v3_validator(fixture_mapping_package_v3_model) -> None:
+    with patch(
+        "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3",
+        return_value=True,
+    ) as mock_v3:
+        assert _validate_model(fixture_mapping_package_v3_model, "v3") is True
+        mock_v3.assert_called_once_with(mapping_package=fixture_mapping_package_v3_model)
+
+
+def test_validate_model_v3_raises_on_wrong_type(dummy_mapping_package_v1_model) -> None:
+    with pytest.raises(CrossVersionValidationError, match="Version 'v3' requires MappingPackageV3"):
+        _validate_model(dummy_mapping_package_v1_model, "v3")
+
+
+def test_validate_model_v3L_calls_v3_lightweight_validator(
+    fixture_mapping_package_v3_model,
+) -> None:
+    v3l_model = convert_mapping_package_v3_to_v3_lightweight(fixture_mapping_package_v3_model)
+    with patch(
+        "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight.validate_mapping_package_v3_lightweight",
+        return_value=True,
+    ) as mock_v3l:
+        assert _validate_model(v3l_model, "v3L") is True
+        mock_v3l.assert_called_once_with(mapping_package=v3l_model)
+
+
+def test_validate_model_v3L_raises_on_wrong_type(fixture_mapping_package_v3_model) -> None:
+    with pytest.raises(
+        CrossVersionValidationError,
+        match="Version 'v3L' requires MappingPackageV3Lightweight",
+    ):
+        _validate_model(fixture_mapping_package_v3_model, "v3L")
+
+
+def test_validate_model_raises_on_unsupported_version(dummy_mapping_package_v1_model) -> None:
+    with pytest.raises(CrossVersionValidationError, match="Unsupported version: v99"):
+        _validate_model(dummy_mapping_package_v1_model, "v99")
+
+
+# --- _validate_folder ---
+
+
+def test_validate_folder_v1_calls_v1_from_folder(tmp_path: Path) -> None:
+    with patch(
+        "mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1.validate_mapping_package_v1_from_folder",
+        return_value=True,
+    ) as mock_v1:
+        assert _validate_folder(tmp_path, "v1") is True
+        mock_v1.assert_called_once_with(mapping_package_folder_path=tmp_path)
+
+
+def test_validate_folder_v2_calls_v2_from_folder(tmp_path: Path) -> None:
+    with patch(
+        "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2_from_folder",
+        return_value=True,
+    ) as mock_v2:
+        assert _validate_folder(tmp_path, "v2") is True
+        mock_v2.assert_called_once_with(mapping_package_folder_path=tmp_path)
+
+
+def test_validate_folder_v3_calls_v3_from_folder(tmp_path: Path) -> None:
+    with patch(
+        "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3_from_folder",
+        return_value=True,
+    ) as mock_v3:
+        assert _validate_folder(tmp_path, "v3") is True
+        mock_v3.assert_called_once_with(mapping_package_folder_path=tmp_path)
+
+
+def test_validate_folder_v3L_calls_v3_lightweight_from_folder(tmp_path: Path) -> None:
+    with patch(
+        "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight.validate_mapping_package_v3_lightweight_from_folder",
+        return_value=True,
+    ) as mock_v3l:
+        assert _validate_folder(tmp_path, "v3L") is True
+        mock_v3l.assert_called_once_with(mapping_package_folder_path=tmp_path)
+
+
+def test_validate_folder_raises_on_unsupported_version(tmp_path: Path) -> None:
+    with pytest.raises(CrossVersionValidationError, match="Unsupported version: v99"):
+        _validate_folder(tmp_path, "v99")
+
+
+# --- validate_mapping_package: archive + unknown version ---
+
+
+def test_validate_mapping_package_archive_raises_clear_error_for_unknown_version(tmp_path: Path) -> None:
+    archive_path = tmp_path / "mp.zip"
+    archive_path.write_text("dummy")
+
+    with (
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.ArchiveExtractor.extract",
+            return_value=tmp_path / "extracted",
+        ),
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version",
+            return_value=None,
+        ),
+    ):
+        with pytest.raises(CrossVersionValidationError, match="Unknown or unsupported mapping package version"):
+            validate_mapping_package(archive_path)
+
+
+# --- validate_mapping_package: auto-detect from model type ---
+
+
+def test_validate_mapping_package_auto_detects_v2_from_model_type(dummy_mapping_package_v2_model) -> None:
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version") as mock_detect,
+        patch(
+            "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2",
+            return_value=True,
+        ) as mock_v2,
+    ):
+        assert validate_mapping_package(dummy_mapping_package_v2_model) is True
+        mock_detect.assert_not_called()
+        mock_v2.assert_called_once_with(mapping_package=dummy_mapping_package_v2_model)
+
+
+def test_validate_mapping_package_auto_detects_v3L_from_model_type(
+    fixture_mapping_package_v3_model,
+) -> None:
+    v3l_model = convert_mapping_package_v3_to_v3_lightweight(fixture_mapping_package_v3_model)
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version") as mock_detect,
+        patch(
+            "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight.validate_mapping_package_v3_lightweight",
+            return_value=True,
+        ) as mock_v3l,
+    ):
+        assert validate_mapping_package(v3l_model) is True
+        mock_detect.assert_not_called()
+        mock_v3l.assert_called_once_with(mapping_package=v3l_model)
+
+
+def test_validate_mapping_package_auto_detects_v3_from_model_type(fixture_mapping_package_v3_model) -> None:
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version") as mock_detect,
+        patch(
+            "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3",
+            return_value=True,
+        ) as mock_v3,
+    ):
+        assert validate_mapping_package(fixture_mapping_package_v3_model) is True
+        mock_detect.assert_not_called()
+        mock_v3.assert_called_once_with(mapping_package=fixture_mapping_package_v3_model)
+
+
+def test_validate_mapping_package_raises_when_model_type_unknown() -> None:
+    with pytest.raises(
+        CrossVersionValidationError,
+        match="Cannot auto-detect version from mapping package type",
+    ):
+        validate_mapping_package("not a package")
 

--- a/tests/unit/tools/services/test_validate_mapping_package.py
+++ b/tests/unit/tools/services/test_validate_mapping_package.py
@@ -314,3 +314,223 @@ def test_validate_mapping_package_raises_when_model_type_unknown() -> None:
         match="Cannot auto-detect version from mapping package type",
     ):
         validate_mapping_package("not a package")
+
+
+def test_validate_mapping_package_raises_on_explicit_unsupported_version_for_path(tmp_path: Path) -> None:
+    """Test that an explicit unsupported version string raises clearly for folder path."""
+    with pytest.raises(CrossVersionValidationError, match="Unsupported version: v99"):
+        validate_mapping_package(tmp_path, version="v99")
+
+
+def test_validate_mapping_package_raises_on_explicit_unsupported_version_for_model(dummy_mapping_package_v1_model) -> None:
+    """Test that an explicit unsupported version string raises clearly for model instance."""
+    with pytest.raises(CrossVersionValidationError, match="Unsupported version: v99"):
+        validate_mapping_package(dummy_mapping_package_v1_model, version="v99")
+
+
+def test_validate_folder_from_path_raises_on_unsupported_version(tmp_path: Path) -> None:
+    """Test that _validate_folder_from_path raises for unsupported version."""
+    with pytest.raises(CrossVersionValidationError, match="Unsupported version"):
+        _validate_folder_from_path(tmp_path, cast(Version, "v99"))
+
+def test_validate_mapping_package_archive_succeeds_with_auto_detection(tmp_path: Path) -> None:
+    """Test that archive validation succeeds when auto-detection works and validation passes."""
+    archive_path = tmp_path / "mp.zip"
+    archive_path.write_text("dummy")
+    extracted_path = tmp_path / "extracted"
+    extracted_path.mkdir()
+
+    with (
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.ArchiveExtractor.extract",
+            return_value=extracted_path,
+        ) as mock_extract,
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version",
+            return_value=Version.V2,
+        ) as mock_detect,
+        patch(
+            "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2_from_folder",
+            return_value=True,
+        ) as mock_v2,
+    ):
+        assert validate_mapping_package(archive_path) is True
+
+        # Verify extract was called with archive_path as first arg
+        assert mock_extract.call_count == 1
+        call_args = mock_extract.call_args[0]
+        assert call_args[0] == archive_path
+
+        mock_detect.assert_called_once_with(extracted_path)
+        mock_v2.assert_called_once_with(mapping_package_folder_path=extracted_path)
+
+
+def test_validate_mapping_package_archive_succeeds_with_explicit_version(tmp_path: Path) -> None:
+    """Test that archive validation with explicit version skips auto-detection."""
+    archive_path = tmp_path / "mp.zip"
+    archive_path.write_text("dummy")
+    extracted_path = tmp_path / "extracted"
+    extracted_path.mkdir()
+
+    with (
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.ArchiveExtractor.extract",
+            return_value=extracted_path,
+        ) as mock_extract,
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version",
+        ) as mock_detect,
+        patch(
+            "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3_from_folder",
+            return_value=True,
+        ) as mock_v3,
+    ):
+        assert validate_mapping_package(archive_path, version="v3") is True
+
+        # Verify extract was called with archive_path as first arg
+        assert mock_extract.call_count == 1
+        call_args = mock_extract.call_args[0]
+        assert call_args[0] == archive_path
+
+        mock_detect.assert_not_called()
+        mock_v3.assert_called_once_with(mapping_package_folder_path=extracted_path)
+
+
+# --- validate_mapping_package: model validation ---
+
+
+def test_validate_mapping_package_raises_on_model_version_mismatch_v1_to_v2(dummy_mapping_package_v1_model) -> None:
+    """Test that providing V1 model with version='v2' raises."""
+    with pytest.raises(CrossVersionValidationError, match="Version 'v2' requires MappingPackageV2"):
+        validate_mapping_package(dummy_mapping_package_v1_model, version="v2")
+
+
+def test_validate_mapping_package_raises_on_model_version_mismatch_v1_to_v3(dummy_mapping_package_v1_model) -> None:
+    """Test that providing V1 model with version='v3' raises."""
+    with pytest.raises(CrossVersionValidationError, match="Version 'v3' requires MappingPackageV3"):
+        validate_mapping_package(dummy_mapping_package_v1_model, version="v3")
+
+
+def test_validate_mapping_package_raises_on_model_version_mismatch_v2_to_v1(dummy_mapping_package_v2_model) -> None:
+    """Test that providing V2 model with version='v1' raises."""
+    with pytest.raises(CrossVersionValidationError, match="Version 'v1' requires MappingPackageV1"):
+        validate_mapping_package(dummy_mapping_package_v2_model, version="v1")
+
+
+def test_validate_mapping_package_raises_on_model_version_mismatch_v2_to_v3(dummy_mapping_package_v2_model) -> None:
+    """Test that providing V2 model with version='v3' raises."""
+    with pytest.raises(CrossVersionValidationError, match="Version 'v3' requires MappingPackageV3"):
+        validate_mapping_package(dummy_mapping_package_v2_model, version="v3")
+
+
+def test_validate_mapping_package_raises_on_model_version_mismatch_v3_to_v1(fixture_mapping_package_v3_model) -> None:
+    """Test that providing V3 model with version='v1' raises."""
+    with pytest.raises(CrossVersionValidationError, match="Version 'v1' requires MappingPackageV1"):
+        validate_mapping_package(fixture_mapping_package_v3_model, version="v1")
+
+
+def test_validate_mapping_package_raises_on_model_version_mismatch_v3_to_v2(fixture_mapping_package_v3_model) -> None:
+    """Test that providing V3 model with version='v2' raises."""
+    with pytest.raises(CrossVersionValidationError, match="Version 'v2' requires MappingPackageV2"):
+        validate_mapping_package(fixture_mapping_package_v3_model, version="v2")
+
+
+def test_validate_mapping_package_raises_on_model_version_mismatch_v3_to_v3L(fixture_mapping_package_v3_model) -> None:
+    """Test that providing V3 model with version='v3L' raises."""
+    with pytest.raises(CrossVersionValidationError, match="Version 'v3L' requires MappingPackageV3Lightweight"):
+        validate_mapping_package(fixture_mapping_package_v3_model, version="v3L")
+
+
+def test_validate_mapping_package_raises_on_model_version_mismatch_v3L_to_v3(fixture_mapping_package_v3_model) -> None:
+    """Test that providing V3L model with version='v3' raises."""
+    v3l_model = convert_mapping_package_v3_to_v3_lightweight(fixture_mapping_package_v3_model)
+    with pytest.raises(CrossVersionValidationError, match="Version 'v3' requires MappingPackageV3"):
+        validate_mapping_package(v3l_model, version="v3")
+
+
+# --- validate_mapping_package: path validation ---
+
+
+def test_validate_mapping_package_raises_on_nonexistent_folder_path(tmp_path: Path) -> None:
+    """Test that validating a non-existent folder path raises."""
+    nonexistent_path = tmp_path / "does_not_exist"
+    with pytest.raises(Exception):
+        validate_mapping_package(nonexistent_path)
+
+
+def test_validate_mapping_package_raises_on_nonexistent_archive_path(tmp_path: Path) -> None:
+    """Test that validating a non-existent archive path raises."""
+    nonexistent_archive = tmp_path / "does_not_exist.zip"
+    with pytest.raises(Exception):
+        validate_mapping_package(nonexistent_archive)
+
+
+def test_validate_mapping_package_raises_on_file_when_folder_expected(tmp_path: Path) -> None:
+    """Test that passing a file path when folder is expected raises."""
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content")
+
+    with (
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version",
+            return_value=Version.V2,
+        ),
+    ):
+        with pytest.raises(Exception):  # validate_folder_path should raise
+            validate_mapping_package(file_path)
+
+
+def test_validate_mapping_package_folder_path_validation_is_called(tmp_path: Path) -> None:
+    """Test that folder path validation is called for directory paths."""
+    folder_path = tmp_path / "package"
+    folder_path.mkdir()
+
+    with (
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.MPValidationStepABC.validate_path_exists",
+        ) as mock_validate_path,
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.MPValidationStepABC.validate_folder_path",
+        ) as mock_validate_folder,
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version",
+            return_value=Version.V2,
+        ),
+        patch(
+            "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2_from_folder",
+            return_value=True,
+        ),
+    ):
+        validate_mapping_package(folder_path)
+        mock_validate_path.assert_called_once()
+        mock_validate_folder.assert_called_once()
+
+
+def test_validate_mapping_package_archive_path_validation_is_called(tmp_path: Path) -> None:
+    """Test that archive path validation is called for file paths."""
+    archive_path = tmp_path / "package.zip"
+    archive_path.write_text("dummy")
+
+    with (
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.MPValidationStepABC.validate_path_exists",
+        ) as mock_validate_path,
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.MPValidationStepABC.validate_archive_path",
+        ) as mock_validate_archive,
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.ArchiveExtractor.extract",
+            return_value=tmp_path / "extracted",
+        ),
+        patch(
+            "mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version",
+            return_value=Version.V2,
+        ),
+        patch(
+            "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2_from_folder",
+            return_value=True,
+        ),
+    ):
+        validate_mapping_package(archive_path)
+        mock_validate_path.assert_called_once()
+        mock_validate_archive.assert_called_once()

--- a/tests/unit/tools/services/test_validate_mapping_package.py
+++ b/tests/unit/tools/services/test_validate_mapping_package.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mapping_suite_sdk.core.adapters.validator import MPValidationException
+from mapping_suite_sdk.tools.services.validate_mapping_package import (
+    CrossVersionValidationError,
+    validate_mapping_package,
+)
+
+
+def test_validate_mapping_package_auto_detects_version_for_folder_path(tmp_path: Path) -> None:
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version", return_value="v2") as mock_detect,
+        patch("mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2_from_folder", return_value=True) as mock_v2,
+    ):
+        assert validate_mapping_package(tmp_path) is True
+        mock_detect.assert_called_once_with(tmp_path)
+        mock_v2.assert_called_once_with(mapping_package_folder_path=tmp_path)
+
+
+def test_validate_mapping_package_explicit_version_skips_detection_for_folder_path(tmp_path: Path) -> None:
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version") as mock_detect,
+        patch("mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3_from_folder", return_value=True) as mock_v3,
+    ):
+        assert validate_mapping_package(tmp_path, version="v3") is True
+        mock_detect.assert_not_called()
+        mock_v3.assert_called_once_with(mapping_package_folder_path=tmp_path)
+
+
+def test_validate_mapping_package_raises_clear_error_for_unknown_version(tmp_path: Path) -> None:
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version", return_value=None),
+    ):
+        with pytest.raises(CrossVersionValidationError, match="Unknown or unsupported mapping package version"):
+            validate_mapping_package(tmp_path)
+
+
+def test_validate_mapping_package_archive_does_not_wrap_validation_errors(tmp_path: Path) -> None:
+    archive_path = tmp_path / "mp.zip"
+    archive_path.write_text("dummy")  # just needs to exist as a file for this test
+
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.ArchiveExtractor.extract", return_value=tmp_path / "extracted") as mock_extract,
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version", return_value="v3L"),
+        patch(
+            "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3_lightweight.validate_mapping_package_v3_lightweight_from_folder",
+            side_effect=MPValidationException("Hash validation failed"),
+        ),
+    ):
+        with pytest.raises(MPValidationException, match="Hash validation failed"):
+            validate_mapping_package(archive_path)
+        mock_extract.assert_called_once()
+
+
+def test_validate_mapping_package_auto_detects_version_from_model_type(dummy_mapping_package_v1_model) -> None:
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version") as mock_detect,
+        patch("mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1.validate_mapping_package_v1", return_value=True) as mock_v1,
+    ):
+        assert validate_mapping_package(dummy_mapping_package_v1_model) is True
+        mock_detect.assert_not_called()
+        mock_v1.assert_called_once()
+
+
+def test_validate_mapping_package_explicit_version_skips_detection_for_model(fixture_mapping_package_v3_model) -> None:
+    with (
+        patch("mapping_suite_sdk.tools.services.validate_mapping_package.detect_mapping_package_version") as mock_detect,
+        patch("mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3", return_value=True) as mock_v3,
+    ):
+        assert validate_mapping_package(fixture_mapping_package_v3_model, version="v3") is True
+        mock_detect.assert_not_called()
+        mock_v3.assert_called_once()
+


### PR DESCRIPTION
Add cross-version validate_mapping_package service with auto-detection

Introduce a single `validate_mapping_package(...)` API that accepts a model or folder/archive path, auto-detects version only when not explicitly provided, and dispatches to the correct version-specific validator. Improve archive handling so validation errors aren’t misreported as ZIP extraction failures. Add unit tests covering auto-detect, explicit version (no detection), and unsupported/unknown version scenarios.

https://meaningfy.atlassian.net/browse/MSSDK1-111