### PR TITLE
Add common mapping package model to share fields

### DIFF
--- a/mapping_suite_sdk/core/models/mapping_package.py
+++ b/mapping_suite_sdk/core/models/mapping_package.py
@@ -1,7 +1,28 @@
+from typing import List
+
+from pydantic import Field
+from mapping_suite_sdk.core.models.collection_asset import SHACLTestCollectionAsset, SPARQLTestCollectionAsset, TechnicalMappingCollectionAsset, TestDataCollectionAsset, TestResultCollectionAsset, VocabularyMappingCollectionAsset
+from mapping_suite_sdk.core.models.file_asset import ConceptualMappingFileAsset
 from mapping_suite_sdk.core.models.pydantic import PydanticModel
 
 
 class MappingPackage(PydanticModel):
     """
-
+        A base class representing the bare minimum of a mapping package across all versions/specializations of the model.
     """
+
+    # Mandatory package elements without which transformation cannot occur
+    technical_mapping_suite: TechnicalMappingCollectionAsset = Field(..., description="RML mapping files containing the technical mapping rules/definitions")
+    vocabulary_mapping_suite: VocabularyMappingCollectionAsset = Field(..., description="Vocabulary resources used by mapping rules in XML, JSON or CSV format")
+
+class MappingPackageCommon(MappingPackage):
+    """
+        A base class representing the common characteristics of a mapping package across some versions/specializations of the model.
+    """
+
+    # Common package elements
+    conceptual_mapping_asset: ConceptualMappingFileAsset | None = Field(None, description="The Conceptual Mapping (CM) in Excel (XLSX) spreadsheet format")
+    test_data_suites: List[TestDataCollectionAsset] = Field(default_factory=list, description="List of test data collections in XML format")
+    test_suites_sparql: List[SPARQLTestCollectionAsset] = Field(default_factory=list, description="List of SPARQL-based validation test suites")
+    test_suites_shacl: SHACLTestCollectionAsset | None = Field(None, description="Container for SHACL-based validation test suites")
+    test_results: TestResultCollectionAsset | None = Field(None, description="Container for transformation test results and outputs")

--- a/mapping_suite_sdk/core/models/mapping_package.py
+++ b/mapping_suite_sdk/core/models/mapping_package.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import Field
 from mapping_suite_sdk.core.models.collection_asset import SHACLTestCollectionAsset, SPARQLTestCollectionAsset, TechnicalMappingCollectionAsset, TestDataCollectionAsset, TestResultCollectionAsset, VocabularyMappingCollectionAsset
@@ -21,8 +21,8 @@ class MappingPackageCommon(MappingPackage):
     """
 
     # Common package elements
-    conceptual_mapping_asset: ConceptualMappingFileAsset | None = Field(None, description="The Conceptual Mapping (CM) in Excel (XLSX) spreadsheet format")
+    conceptual_mapping_asset: Optional[ConceptualMappingFileAsset] = Field(None, description="The Conceptual Mapping (CM) in Excel (XLSX) spreadsheet format")
     test_data_suites: List[TestDataCollectionAsset] = Field(default_factory=list, description="List of test data collections in XML format")
     test_suites_sparql: List[SPARQLTestCollectionAsset] = Field(default_factory=list, description="List of SPARQL-based validation test suites")
-    test_suites_shacl: SHACLTestCollectionAsset | None = Field(None, description="Container for SHACL-based validation test suites")
-    test_results: TestResultCollectionAsset | None = Field(None, description="Container for transformation test results and outputs")
+    test_suites_shacl: Optional[SHACLTestCollectionAsset] = Field(None, description="Container for SHACL-based validation test suites")
+    test_results: Optional[TestResultCollectionAsset] = Field(None, description="Container for transformation test results and outputs")

--- a/mapping_suite_sdk/mapping_package_v1/models/mapping_package_v1.py
+++ b/mapping_suite_sdk/mapping_package_v1/models/mapping_package_v1.py
@@ -1,16 +1,10 @@
-from typing import List
-
 from pydantic import Field
 
-from mapping_suite_sdk.core.models.collection_asset import TestDataCollectionAsset, TestResultCollectionAsset, \
-    SHACLTestCollectionAsset, \
-    SPARQLTestCollectionAsset, TechnicalMappingCollectionAsset, VocabularyMappingCollectionAsset
-from mapping_suite_sdk.core.models.file_asset import ConceptualMappingFileAsset
-from mapping_suite_sdk.core.models.mapping_package import MappingPackage
+from mapping_suite_sdk.core.models.mapping_package import MappingPackageCommon
 from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1_metadata import MappingPackageV1Metadata
 
 
-class MappingPackageV1(MappingPackage):
+class MappingPackageV1(MappingPackageCommon):
     """
         A class representing a complete V1 (used in Standard Forms mappings) mapping package configuration.
 
@@ -20,20 +14,4 @@ class MappingPackageV1(MappingPackage):
         mapping project.
     """
 
-    # Metadata
-    metadata: MappingPackageV1Metadata = Field(...,
-                                               description="Package metadata containing general information")
-
-    # Package elements (folders and files)
-    conceptual_mapping_asset: ConceptualMappingFileAsset = Field(..., description="The CMs in Excel Spreadsheet")
-    technical_mapping_suite: TechnicalMappingCollectionAsset = Field(...,
-                                                                     description="All teh RML files, which are RMLFragments")
-    vocabulary_mapping_suite: VocabularyMappingCollectionAsset = Field(...,
-                                                                       description="The resources JSONs, CSV and XML files")
-    test_data_suites: List[TestDataCollectionAsset] = Field(...,
-                                                            description="Collections of test data for transformation")
-    test_suites_sparql: List[SPARQLTestCollectionAsset] = Field(...,
-                                                                description="Collections of SPARQL-based test suites")
-    test_suites_shacl: SHACLTestCollectionAsset = Field(...,
-                                                        description="Collections of SHACL-based validation test suites")
-    test_results: TestResultCollectionAsset = Field(..., description="Collections of test transformation results")
+    metadata: MappingPackageV1Metadata = Field(..., description="Package metadata containing general information")

--- a/mapping_suite_sdk/mapping_package_v2/models/mapping_package_v2.py
+++ b/mapping_suite_sdk/mapping_package_v2/models/mapping_package_v2.py
@@ -1,38 +1,10 @@
-from typing import List
-
 from pydantic import Field
 
-from mapping_suite_sdk.core.models.collection_asset import TechnicalMappingCollectionAsset, \
-    VocabularyMappingCollectionAsset, TestDataCollectionAsset, SPARQLTestCollectionAsset, SHACLTestCollectionAsset, \
-    TestResultCollectionAsset
-from mapping_suite_sdk.core.models.file_asset import ConceptualMappingFileAsset
-from mapping_suite_sdk.core.models.mapping_package import MappingPackage
+from mapping_suite_sdk.core.models.mapping_package import MappingPackageCommon
 from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2_metadata import MappingPackageV2Metadata
 
 
-# class MappingSource(PydanticModel):
-#     """A class representing the source data configuration in a mapping package.
-#
-#     This class defines the characteristics of the source data that will be
-#     transformed. It includes information about the source data format and version.
-#     """
-#     title: str = Field(..., min_length=STR_MIN_LENGTH, max_length=STR_MAX_LENGTH,
-#                        description="Example: Standard Forms XSD R09.S01")
-#     version: str = Field(..., min_length=STR_MIN_LENGTH, max_length=STR_MAX_LENGTH, alias="mapping_version")
-#
-#
-# class MappingTarget(PydanticModel):
-#     """A class representing the target data configuration in a mapping package.
-#
-#     This class defines the characteristics of the target data format that the
-#     source data will be transformed into. It includes information about the
-#     target ontology or data model and its version.
-#     """
-#     title: str = Field(..., min_length=STR_MIN_LENGTH, max_length=STR_MAX_LENGTH, description="Example: ePO v4.0.0")
-#     version: str = Field(..., min_length=STR_MIN_LENGTH, max_length=STR_MAX_LENGTH, alias="ontology_version")
-
-
-class MappingPackageV2(MappingPackage):
+class MappingPackageV2(MappingPackageCommon):
     """
         A class representing a complete V2 (eForms) mapping package configuration.
 
@@ -42,19 +14,4 @@ class MappingPackageV2(MappingPackage):
         mapping project.
     """
 
-    # Metadata
     metadata: MappingPackageV2Metadata = Field(..., description="Package metadata containing general information")
-
-    # Package elements (folders and files)
-    conceptual_mapping_asset: ConceptualMappingFileAsset = Field(..., description="The CMs in Excel Spreadsheet")
-    technical_mapping_suite: TechnicalMappingCollectionAsset = Field(...,
-                                                                     description="All teh RML files, which are RMLFragments")
-    vocabulary_mapping_suite: VocabularyMappingCollectionAsset = Field(...,
-                                                                       description="The resources JSONs, CSV and XML files")
-    test_data_suites: List[TestDataCollectionAsset] = Field(...,
-                                                            description="Collections of test data for transformation")
-    test_suites_sparql: List[SPARQLTestCollectionAsset] = Field(...,
-                                                                description="Collections of SPARQL-based test suites")
-    test_suites_shacl: SHACLTestCollectionAsset = Field(...,
-                                                        description="Collections of SHACL-based validation test suites")
-    test_results: TestResultCollectionAsset = Field(..., description="Collections of test transformation results")

--- a/mapping_suite_sdk/mapping_package_v3/models/mapping_package_v3.py
+++ b/mapping_suite_sdk/mapping_package_v3/models/mapping_package_v3.py
@@ -1,17 +1,11 @@
-from typing import List
-
 from pydantic import Field
 
-from mapping_suite_sdk.core.models.collection_asset import TechnicalMappingCollectionAsset, \
-    VocabularyMappingCollectionAsset, TestDataCollectionAsset, SPARQLTestCollectionAsset, SHACLTestCollectionAsset, \
-    TestResultCollectionAsset
-from mapping_suite_sdk.core.models.file_asset import ConceptualMappingFileAsset
-from mapping_suite_sdk.core.models.mapping_package import MappingPackage
+from mapping_suite_sdk.core.models.mapping_package import MappingPackageCommon
 from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3_metadata_jsonld import \
     MappingPackageV3MetadataJSONLD
 
 
-class MappingPackageV3(MappingPackage):
+class MappingPackageV3(MappingPackageCommon):
     """
         A class representing a complete V3 (Unified) mapping package configuration.
 
@@ -21,19 +15,4 @@ class MappingPackageV3(MappingPackage):
         mapping project.
     """
 
-    # Metadata
     metadata: MappingPackageV3MetadataJSONLD = Field(..., description="Package metadata containing general information")
-
-    # Package elements (folders and files)
-    conceptual_mapping_asset: ConceptualMappingFileAsset = Field(..., description="The CMs in Excel Spreadsheet")
-    technical_mapping_suite: TechnicalMappingCollectionAsset = Field(...,
-                                                                     description="All teh RML files, which are RMLFragments")
-    vocabulary_mapping_suite: VocabularyMappingCollectionAsset = Field(...,
-                                                                       description="The resources JSONs, CSV and XML files")
-    test_data_suites: List[TestDataCollectionAsset] = Field(...,
-                                                            description="Collections of test data for transformation")
-    test_suites_sparql: List[SPARQLTestCollectionAsset] = Field(...,
-                                                                description="Collections of SPARQL-based test suites")
-    test_suites_shacl: SHACLTestCollectionAsset = Field(...,
-                                                        description="Collections of SHACL-based validation test suites")
-    test_results: TestResultCollectionAsset = Field(..., description="Collections of test transformation results")

--- a/mapping_suite_sdk/mapping_package_v3/models/mapping_package_v3_lightweight.py
+++ b/mapping_suite_sdk/mapping_package_v3/models/mapping_package_v3_lightweight.py
@@ -1,7 +1,6 @@
+from typing import List
 from pydantic import Field
 
-from mapping_suite_sdk.core.models.collection_asset import TechnicalMappingCollectionAsset, \
-    VocabularyMappingCollectionAsset
 from mapping_suite_sdk.core.models.mapping_package import MappingPackage
 from mapping_suite_sdk.mapping_package_v3.models.mapping_package_v3_metadata_jsonld import \
     MappingPackageV3MetadataJSONLD
@@ -17,11 +16,4 @@ class MappingPackageV3Lightweight(MappingPackage):
         namely the technical mapping rules and associated vocabulary resources only.
     """
 
-    # Metadata
     metadata: MappingPackageV3MetadataJSONLD = Field(..., description="Package metadata containing general information")
-
-    # Package elements (folders and files)
-    technical_mapping_suite: TechnicalMappingCollectionAsset = Field(...,
-                                                                     description="All the RML files, which are RMLFragments")
-    vocabulary_mapping_suite: VocabularyMappingCollectionAsset = Field(...,
-                                                                       description="The resources JSONs, CSV and XML files")


### PR DESCRIPTION
The base class should only have what is needed also in the Lightweight model. All other fields should be delegated to a separate, "common" class.

Also make non-essential fields optional. This may be required for some use cases where our models are extended.