### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-tag-pypi-publish.yaml
+++ b/.github/workflows/release-tag-pypi-publish.yaml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "*.*.*"
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/meaningfy-ws/mapping-suite-sdk/security/code-scanning/1](https://github.com/meaningfy-ws/mapping-suite-sdk/security/code-scanning/1)

In general, the problem is fixed by adding an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal rights needed. Since this workflow only checks out code and uses a separate PyPI token for publishing, it only requires read access to repository contents. Defining `permissions: contents: read` at the workflow root will apply to all jobs and document the intended minimal permissions.

Concretely, in `.github/workflows/release-tag-pypi-publish.yaml`, add a `permissions` block near the top of the workflow (at the same indentation level as `on:` and `jobs:`). The block should specify `contents: read`, which is sufficient for `actions/checkout` to function. No other permissions are required because the publish step uses `secrets.PYPI_TOKEN` against PyPI, not GitHub. No additional imports or methods are needed since this is a configuration-only change in the YAML workflow file, and it does not alter the existing functionality of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
