### PR TITLE
Bugfix for conversion before and after validation

### DIFF
--- a/mapping_suite_sdk/tools/services/convert_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/convert_mapping_package.py
@@ -314,13 +314,15 @@ def convert_mapping_package_from_folder(
     Convert a mapping package from filesystem to filesystem.
 
     Complete workflow:
-    1. Load package from folder
-    2. Convert package model
-    3. Serialize converted package back to folder
-    4. Handle file operations (context.jsonld, cleanup)
+    1. Validate source package (fail if broken; no conversion of invalid packages)
+    2. Load package from folder
+    3. Convert package model (hash is updated on the converted model)
+    4. Serialize converted package back to folder
+    5. Handle file operations (context.jsonld, cleanup)
+    6. Validate converted package (ensures hash and structure are sane)
 
     Args:
-        from_version: Source version (v2 or v3)
+        from_version: Source version (v1, v2 or v3)
         to_version: Target version (v3 or v3L)
         mapping_package_folder_path: Path to the mapping package folder
 
@@ -329,10 +331,24 @@ def convert_mapping_package_from_folder(
         UnsupportedVersionError: If version or conversion is not supported
         FileNotFoundError: If required files are missing
         ConversionError: For other conversion errors
+        MPValidationException: If source package fails validation (pre-conversion)
+            or converted package fails validation (post-conversion)
     """
+    if not mapping_package_folder_path.exists():
+        raise InvalidPackagePathError(f"Package path does not exist: {mapping_package_folder_path}")
+    if not mapping_package_folder_path.is_dir():
+        raise InvalidPackagePathError(f"Package path is not a directory: {mapping_package_folder_path}")
+
+    # Pre-conversion: validate source package; abort if invalid (e.g. wrong hash)
+    from mapping_suite_sdk.tools.services.validate_mapping_package import validate_mapping_package
+    validate_mapping_package(mapping_package_folder_path, version=from_version)
+
     source_package = load_mapping_package_from_folder(from_version, mapping_package_folder_path)
     converted_package = convert_mapping_package_model(from_version, to_version, source_package)
     serialise_mapping_package(to_version, mapping_package_folder_path, converted_package)
+
+    # Post-conversion: validate converted package (hash already updated by converters)
+    validate_mapping_package(converted_package)
 
 @traced_routine
 def convert_mapping_packages_from_folder(

--- a/tests/unit/tools/services/test_convert_mapping_package.py
+++ b/tests/unit/tools/services/test_convert_mapping_package.py
@@ -420,6 +420,22 @@ class TestSerialiseMappingPackage:
 class TestConvertMappingPackageFromFolder:
     """Tests for convert_mapping_package_from_folder orchestration function."""
 
+    def test_convert_package_invalid_path_not_exists(self, tmp_path: Path):
+        """Test that non-existent package path raises InvalidPackagePathError."""
+        invalid_path = tmp_path / "nonexistent"
+
+        with pytest.raises(InvalidPackagePathError, match="does not exist"):
+            convert_mapping_package_from_folder(Version.V2, Version.V3, invalid_path)
+
+    def test_convert_package_invalid_path_not_directory(self, tmp_path: Path):
+        """Test that file path (not directory) raises InvalidPackagePathError."""
+        file_path = tmp_path / "file.txt"
+        file_path.write_text("test")
+
+        with pytest.raises(InvalidPackagePathError, match="not a directory"):
+            convert_mapping_package_from_folder(Version.V2, Version.V3, file_path)
+
+    @patch('mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.serialise_mapping_package')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.convert_mapping_package_model')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.load_mapping_package_from_folder')
@@ -428,28 +444,50 @@ class TestConvertMappingPackageFromFolder:
         mock_load,
         mock_convert,
         mock_serialise,
+        mock_validate,
         tmp_path: Path
     ):
-        """Test complete conversion workflow: load -> convert -> serialize."""
+        """Test complete conversion workflow: validate -> load -> convert -> serialize -> validate."""
         mock_source = Mock()
         mock_converted = Mock()
         mock_load.return_value = mock_source
         mock_convert.return_value = mock_converted
+        mock_validate.return_value = True
 
         convert_mapping_package_from_folder(Version.V2, Version.V3, tmp_path)
 
+        assert mock_validate.call_count == 2
+        mock_validate.assert_any_call(tmp_path, version=Version.V2)
+        mock_validate.assert_any_call(mock_converted)
         mock_load.assert_called_once_with(Version.V2, tmp_path)
         mock_convert.assert_called_once_with(Version.V2, Version.V3, mock_source)
         mock_serialise.assert_called_once_with(Version.V3, tmp_path, mock_converted)
 
+    @patch('mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.load_mapping_package_from_folder')
-    def test_convert_package_hard_fail_on_load_error(self, mock_load, tmp_path: Path):
+    def test_convert_package_fails_on_pre_validation_error(self, mock_load, mock_validate, tmp_path: Path):
+        """Test that invalid source package (e.g. wrong hash) aborts conversion."""
+        from mapping_suite_sdk.core.adapters.validator import MPValidationException
+
+        mock_validate.side_effect = MPValidationException("Hash validation failed")
+
+        with pytest.raises(MPValidationException, match="Hash validation failed"):
+            convert_mapping_package_from_folder(Version.V2, Version.V3, tmp_path)
+
+        mock_validate.assert_called_once_with(tmp_path, version=Version.V2)
+        mock_load.assert_not_called()
+
+    @patch('mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package')
+    @patch('mapping_suite_sdk.tools.services.convert_mapping_package.load_mapping_package_from_folder')
+    def test_convert_package_hard_fail_on_load_error(self, mock_load, mock_validate, tmp_path: Path):
         """Test that load errors propagate (hard fail)."""
+        mock_validate.return_value = True
         mock_load.side_effect = InvalidPackagePathError("Load failed")
 
         with pytest.raises(InvalidPackagePathError, match="Load failed"):
             convert_mapping_package_from_folder(Version.V2, Version.V3, tmp_path)
 
+    @patch('mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.serialise_mapping_package')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.convert_mapping_package_model')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.load_mapping_package_from_folder')
@@ -458,9 +496,11 @@ class TestConvertMappingPackageFromFolder:
         mock_load,
         mock_convert,
         mock_serialise,
+        mock_validate,
         tmp_path: Path
     ):
         """Test that convert errors propagate (hard fail)."""
+        mock_validate.return_value = True
         mock_load.return_value = Mock()
         mock_convert.side_effect = UnsupportedVersionError("Convert failed")
 
@@ -469,6 +509,7 @@ class TestConvertMappingPackageFromFolder:
 
         mock_serialise.assert_not_called()
 
+    @patch('mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.serialise_mapping_package')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.convert_mapping_package_model')
     @patch('mapping_suite_sdk.tools.services.convert_mapping_package.load_mapping_package_from_folder')
@@ -477,15 +518,42 @@ class TestConvertMappingPackageFromFolder:
         mock_load,
         mock_convert,
         mock_serialise,
+        mock_validate,
         tmp_path: Path
     ):
         """Test that serialize errors propagate (hard fail)."""
+        mock_validate.return_value = True
         mock_load.return_value = Mock()
         mock_convert.return_value = Mock()
         mock_serialise.side_effect = FileNotFoundError("context.jsonld not found")
 
         with pytest.raises(FileNotFoundError, match="context.jsonld not found"):
             convert_mapping_package_from_folder(Version.V2, Version.V3, tmp_path)
+
+    @patch('mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package')
+    @patch('mapping_suite_sdk.tools.services.convert_mapping_package.serialise_mapping_package')
+    @patch('mapping_suite_sdk.tools.services.convert_mapping_package.convert_mapping_package_model')
+    @patch('mapping_suite_sdk.tools.services.convert_mapping_package.load_mapping_package_from_folder')
+    def test_convert_package_hard_fail_on_post_validation_error(
+        self,
+        mock_load,
+        mock_convert,
+        mock_serialise,
+        mock_validate,
+        tmp_path: Path
+    ):
+        """Test that post-conversion validation failure propagates."""
+        from mapping_suite_sdk.core.adapters.validator import MPValidationException
+
+        mock_validate.side_effect = [True, MPValidationException("Hash mismatch after conversion")]
+        mock_load.return_value = Mock()
+        mock_convert.return_value = Mock()
+        mock_serialise.return_value = None
+
+        with pytest.raises(MPValidationException, match="Hash mismatch after conversion"):
+            convert_mapping_package_from_folder(Version.V2, Version.V3, tmp_path)
+
+        assert mock_validate.call_count == 2
 
 
 class TestConvertMappingPackagesFromFolder:


### PR DESCRIPTION
https://meaningfy.atlassian.net/browse/MSSDK1-116

In order to replicate the error and see that is solved one could follow the following steps. 

1. Copy the package to a working folder
```
cp -r tests/test_data/mapping_package_v2/package_eforms_29_v1.9_changed /tmp/v2_repro
cd YOUR_PATH/mapping-suite-sdkcp -r tests/test_data/mapping_package_v2/package_eforms_29_v1.9_changed /tmp/v2_repro
```

2. Validate v2 (should pass)
`mssdk validate --version v2 from-folder /tmp/v2_repro`


3. Break the package (change something under transformation)
```
echo "x" >> /tmp/v2_repro/package_eforms_29_v1.9_changed/transformation/mappings/Lot_v1.4+.rml.ttl
# e.g. append a character so the hash no longer matchesecho "x" >> /tmp/v2_repro/package_eforms_29_v1.9_changed/transformation/mappings/Lot_v1.4+.rml.ttl
Or remove a resource:
# rm /tmp/v2_repro/package_eforms_29_v1.9_changed/transformation/resources/accessibility.json
```

4. Validate v2 again (should fail)
`mssdk validate --version v2 from-folder /tmp/v2_repro`


5. Convert v2 → v3L (should fail with the fix)
`mssdk convert --to-version v3L --from-version v2 from-folder /tmp/v2_repro`
With the pre-conversion validation fix, this should fail (e.g. validation error) and the package should not be converted to v3L.

6. (Optional) Convert a single package by path
Same idea, but targeting the package root directly:
`mssdk convert --to-version v3L --from-version v2 from-package `