### PR TITLE
Do not close repository connection as we don't own it

### DIFF
--- a/mapping_suite_sdk/core/adapters/repository.py
+++ b/mapping_suite_sdk/core/adapters/repository.py
@@ -121,6 +121,3 @@ class MongoDBRepository(RepositoryABC[T]):
 
         if result.deleted_count < 1:
             raise ModelNotFoundError(f"Asset with ID {model_id} not found")
-
-    def __del__(self):
-        self.client.close()


### PR DESCRIPTION
By closing the connection ourselves, we force callers to deal with database connection issues whereby clients may be garbage-collected and closed at any point. For example, Airflow will see prematurely closed connections in between related DAG runs. It is therefore not the library's (our) responsibility to close a connection.