### PR TITLE
feature: warning on validators

### DIFF
--- a/mapping_suite_sdk/core/adapters/validator.py
+++ b/mapping_suite_sdk/core/adapters/validator.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from types import FunctionType
-from typing import Optional, Literal, NoReturn
+from typing import Optional, Literal, NoReturn, Any
 
 from mapping_suite_sdk import mssdk_config
 from mapping_suite_sdk.core.models.mapping_package import MappingPackage
@@ -11,6 +11,28 @@ logger = logging.getLogger(__name__)
 
 
 class MPValidationException(Exception): pass
+
+
+def warn_on_empty_test_result_suites(mapping_package: Any) -> None:
+    """
+    Emit warnings (not errors) for empty/unexpected test result suites.
+
+    Outputs (test results) are not required for a mapping package to be loadable/processable.
+    Some production packages may contain partial or unexpected output structures; we warn
+    to surface the issue without blocking validation.
+    """
+    test_results = getattr(mapping_package, "test_results", None)
+    if not test_results:
+        return
+
+    suites = getattr(test_results, "result_suites", None) or []
+    for suite in suites:
+        if not getattr(suite, "files", None):
+            suite_path = getattr(suite, "path", "<unknown>")
+            logger.warning(
+                "Mapping Package structural warning: empty test result suite at %s",
+                suite_path,
+            )
 
 
 def validate_next(func: FunctionType):

--- a/mapping_suite_sdk/mapping_package_v1/adapters/mp_v1_validator.py
+++ b/mapping_suite_sdk/mapping_package_v1/adapters/mp_v1_validator.py
@@ -1,13 +1,15 @@
-import logging
 from typing import final, Optional, NoReturn, Literal
 
 from mapping_suite_sdk.core.adapters.hasher import HasherABC
 from mapping_suite_sdk.core.adapters.tracer import traced_class
-from mapping_suite_sdk.core.adapters.validator import MPValidationException, MPValidationStepABC, validate_next
+from mapping_suite_sdk.core.adapters.validator import (
+    MPValidationException,
+    MPValidationStepABC,
+    validate_next,
+    warn_on_empty_test_result_suites,
+)
 from mapping_suite_sdk.mapping_package_v1.adapters.mp_v1_hasher import MappingPackageV1Hasher
 from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1 import MappingPackageV1
-
-logger = logging.getLogger(__name__)
 
 
 class MPStructuralValidationException(MPValidationException): pass
@@ -39,16 +41,7 @@ class MPV1StructuralValidationStep(MPValidationStepABC):
                 assert suite.files
 
             if mapping_package.test_results:
-                # Outputs (test results) are not required for a package to be loadable.
-                # Some production packages may contain unexpected/partial output structures.
-                suites = getattr(mapping_package.test_results, "result_suites", None) or []
-                for suite in suites:
-                    if not getattr(suite, "files", None):
-                        suite_path = getattr(suite, "path", "<unknown>")
-                        logger.warning(
-                            "Mapping Package structural warning: empty test result suite at %s",
-                            suite_path,
-                        )
+                warn_on_empty_test_result_suites(mapping_package)
 
         # TODO: structural validation also must check relation between test data and results
 

--- a/mapping_suite_sdk/mapping_package_v1/adapters/mp_v1_validator.py
+++ b/mapping_suite_sdk/mapping_package_v1/adapters/mp_v1_validator.py
@@ -1,3 +1,4 @@
+import logging
 from typing import final, Optional, NoReturn, Literal
 
 from mapping_suite_sdk.core.adapters.hasher import HasherABC
@@ -5,6 +6,8 @@ from mapping_suite_sdk.core.adapters.tracer import traced_class
 from mapping_suite_sdk.core.adapters.validator import MPValidationException, MPValidationStepABC, validate_next
 from mapping_suite_sdk.mapping_package_v1.adapters.mp_v1_hasher import MappingPackageV1Hasher
 from mapping_suite_sdk.mapping_package_v1.models.mapping_package_v1 import MappingPackageV1
+
+logger = logging.getLogger(__name__)
 
 
 class MPStructuralValidationException(MPValidationException): pass
@@ -36,8 +39,16 @@ class MPV1StructuralValidationStep(MPValidationStepABC):
                 assert suite.files
 
             if mapping_package.test_results:
-                for suite in mapping_package.test_results.result_suites:
-                    assert suite.files
+                # Outputs (test results) are not required for a package to be loadable.
+                # Some production packages may contain unexpected/partial output structures.
+                suites = getattr(mapping_package.test_results, "result_suites", None) or []
+                for suite in suites:
+                    if not getattr(suite, "files", None):
+                        suite_path = getattr(suite, "path", "<unknown>")
+                        logger.warning(
+                            "Mapping Package structural warning: empty test result suite at %s",
+                            suite_path,
+                        )
 
         # TODO: structural validation also must check relation between test data and results
 

--- a/mapping_suite_sdk/mapping_package_v2/adapters/mp_v2_validator.py
+++ b/mapping_suite_sdk/mapping_package_v2/adapters/mp_v2_validator.py
@@ -1,3 +1,4 @@
+import logging
 from typing import final, Optional, NoReturn, Literal
 
 from mapping_suite_sdk.core.adapters.hasher import HasherABC
@@ -5,6 +6,8 @@ from mapping_suite_sdk.core.adapters.tracer import traced_class
 from mapping_suite_sdk.core.adapters.validator import MPValidationException, MPValidationStepABC, validate_next
 from mapping_suite_sdk.mapping_package_v2.adapters.mp_v2_hasher import MappingPackageV2Hasher
 from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2 import MappingPackageV2
+
+logger = logging.getLogger(__name__)
 
 
 class MPStructuralValidationException(MPValidationException): pass
@@ -36,8 +39,16 @@ class MPV2StructuralValidationStep(MPValidationStepABC):
                 assert suite.files
 
             if mapping_package.test_results:
-                for suite in mapping_package.test_results.result_suites:
-                    assert suite.files
+                # Outputs (test results) are not required for a package to be loadable.
+                # Some production packages may contain unexpected/partial output structures.
+                suites = getattr(mapping_package.test_results, "result_suites", None) or []
+                for suite in suites:
+                    if not getattr(suite, "files", None):
+                        suite_path = getattr(suite, "path", "<unknown>")
+                        logger.warning(
+                            "Mapping Package structural warning: empty test result suite at %s",
+                            suite_path,
+                        )
 
         # TODO: structural validation also must check relation between test data and results
 

--- a/mapping_suite_sdk/mapping_package_v2/adapters/mp_v2_validator.py
+++ b/mapping_suite_sdk/mapping_package_v2/adapters/mp_v2_validator.py
@@ -1,13 +1,15 @@
-import logging
 from typing import final, Optional, NoReturn, Literal
 
 from mapping_suite_sdk.core.adapters.hasher import HasherABC
 from mapping_suite_sdk.core.adapters.tracer import traced_class
-from mapping_suite_sdk.core.adapters.validator import MPValidationException, MPValidationStepABC, validate_next
+from mapping_suite_sdk.core.adapters.validator import (
+    MPValidationException,
+    MPValidationStepABC,
+    validate_next,
+    warn_on_empty_test_result_suites,
+)
 from mapping_suite_sdk.mapping_package_v2.adapters.mp_v2_hasher import MappingPackageV2Hasher
 from mapping_suite_sdk.mapping_package_v2.models.mapping_package_v2 import MappingPackageV2
-
-logger = logging.getLogger(__name__)
 
 
 class MPStructuralValidationException(MPValidationException): pass
@@ -39,16 +41,7 @@ class MPV2StructuralValidationStep(MPValidationStepABC):
                 assert suite.files
 
             if mapping_package.test_results:
-                # Outputs (test results) are not required for a package to be loadable.
-                # Some production packages may contain unexpected/partial output structures.
-                suites = getattr(mapping_package.test_results, "result_suites", None) or []
-                for suite in suites:
-                    if not getattr(suite, "files", None):
-                        suite_path = getattr(suite, "path", "<unknown>")
-                        logger.warning(
-                            "Mapping Package structural warning: empty test result suite at %s",
-                            suite_path,
-                        )
+                warn_on_empty_test_result_suites(mapping_package)
 
         # TODO: structural validation also must check relation between test data and results
 

--- a/tests/unit/core/adapters/test_loader.py
+++ b/tests/unit/core/adapters/test_loader.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+import logging
 
 from mapping_suite_sdk.core.adapters.loader import (
     TechnicalMappingSuiteLoader,
@@ -13,6 +14,7 @@ from mapping_suite_sdk.core.adapters.loader import (
     TestResultSuiteLoader,
     ConceptualMappingFileLoader, load_file_by_extensions
 )
+from mapping_suite_sdk.core.adapters.validator import warn_on_empty_test_result_suites
 from mapping_suite_sdk.core.models.collection_asset import (
     TechnicalMappingCollectionAsset,
     VocabularyMappingCollectionAsset,
@@ -63,6 +65,21 @@ def test_load_file_by_extensions(tmp_path: Path):
     non_existent_file = test_dir / "non_existent.txt"
     non_existent_content = load_file_by_extensions(non_existent_file, str_extensions, bytes_extensions)
     assert non_existent_content is None
+
+
+class _DummyMappingPackage:
+    def __init__(self, test_results):
+        self.test_results = test_results
+
+
+def test_warn_on_empty_test_result_suites_returns_when_no_test_results(caplog):
+    """Covers early return branch in warn_on_empty_test_result_suites."""
+    caplog.set_level(logging.WARNING)
+
+    warn_on_empty_test_result_suites(_DummyMappingPackage(test_results=None))
+
+    # No warning should be emitted when test_results is absent/None
+    assert caplog.text == ""
 
 
 def test_technical_mapping_suite_loader(dummy_mapping_package_path: Path,

--- a/tests/unit/mapping_package_v1/adapters/test_mp_v1_validator.py
+++ b/tests/unit/mapping_package_v1/adapters/test_mp_v1_validator.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+import logging
 
 from mapping_suite_sdk.core.models.collection_asset import (
     TestDataCollectionAsset,
@@ -161,7 +162,7 @@ def test_mp_v1_structural_validation_step_empty_sparql_suite():
         validator.validate(mock_package)
 
 
-def test_mp_v1_structural_validation_step_empty_test_results_suite():
+def test_mp_v1_structural_validation_step_empty_test_results_suite(caplog):
     mock_package = Mock(spec=MappingPackageV1)
 
     mock_package.test_data_suites = [
@@ -205,9 +206,12 @@ def test_mp_v1_structural_validation_step_empty_test_results_suite():
     )
 
     validator = MPV1StructuralValidationStep()
+    caplog.set_level(logging.WARNING)
 
-    with pytest.raises(MPStructuralValidationException):
-        validator.validate(mock_package)
+    # Should not raise structural error for empty output suites
+    result = validator.validate(mock_package)
+    assert result is True
+    assert "empty test result suite" in caplog.text
 
 
 def test_mp_v1_structural_validation_step_none_test_data_suites():

--- a/tests/unit/mapping_package_v2/adapters/test_mp_v2_validator.py
+++ b/tests/unit/mapping_package_v2/adapters/test_mp_v2_validator.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+import logging
 
 from mapping_suite_sdk.core.models.collection_asset import (
     TestDataCollectionAsset,
@@ -151,7 +152,7 @@ def test_mp_v2_structural_validation_step_empty_sparql_suite():
         validator.validate(mock_package)
 
 
-def test_mp_v2_structural_validation_step_empty_test_results_suite():
+def test_mp_v2_structural_validation_step_empty_test_results_suite(caplog):
     mock_package = Mock(spec=MappingPackageV2)
 
     mock_package.test_data_suites = [
@@ -196,8 +197,12 @@ def test_mp_v2_structural_validation_step_empty_test_results_suite():
 
     validator = MPV2StructuralValidationStep()
 
-    with pytest.raises(MPStructuralValidationException):
-        validator.validate(mock_package)
+    caplog.set_level(logging.WARNING)
+
+    # Should not raise structural error for empty output suites
+    result = validator.validate(mock_package)
+    assert result is True
+    assert "empty test result suite" in caplog.text
 
 
 def test_mp_v2_structural_validation_step_none_test_data_suites():


### PR DESCRIPTION
https://meaningfy.atlassian.net/browse/MSSDK1-123

Updated v1/v2 structural validation so empty/unexpected test_results suites don’t raise MPStructuralValidationException anymore.

Those cases now log warnings and still pass validation (True), with v3 left unchanged (hash-only).