### PR TITLE
Support test_data and output params in shortcut loading service

### DIFF
--- a/mapping_suite_sdk/tools/services/load_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/load_mapping_package.py
@@ -27,7 +27,6 @@ from mapping_suite_sdk.tools.services.convert_mapping_package import (
     UnsupportedVersionError,
     Version,
     convert_mapping_package_model,
-    load_mapping_package_from_folder,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,16 +56,58 @@ def _normalize_version(version: str) -> Version:
     return _VERSION_MAP[normalized]
 
 
-def _load_source_package(version: Version, package_folder_path: Path):
+def _load_source_package(
+    version: Version,
+    package_folder_path: Path,
+    include_test_data: bool,
+    include_output: bool,
+):
     """Load a mapping package from folder using the version-specific loader."""
+    if version == Version.V1:
+        from mapping_suite_sdk.mapping_package_v1.adapters.mp_v1_loader import MappingPackageV1Loader
+        from mapping_suite_sdk.mapping_package_v1.services.load_mapping_package_v1 import (
+            load_mapping_package_v1_from_folder,
+        )
+        loader = MappingPackageV1Loader(include_test_data=include_test_data, include_output=include_output)
+        return load_mapping_package_v1_from_folder(
+            mapping_package_folder_path=package_folder_path,
+            mapping_package_loader=loader,
+        )
+    if version == Version.V2:
+        from mapping_suite_sdk.mapping_package_v2.adapters.mp_v2_loader import MappingPackageV2Loader
+        from mapping_suite_sdk.mapping_package_v2.services.load_mapping_package_v2 import (
+            load_mapping_package_v2_from_folder,
+        )
+        loader = MappingPackageV2Loader(include_test_data=include_test_data, include_output=include_output)
+        return load_mapping_package_v2_from_folder(
+            mapping_package_folder_path=package_folder_path,
+            mapping_package_loader=loader,
+        )
+    if version == Version.V3:
+        from mapping_suite_sdk.mapping_package_v3.adapters.mp_v3_package_loader import MappingPackageV3Loader
+        from mapping_suite_sdk.mapping_package_v3.services.load_mapping_package_v3 import (
+            load_mapping_package_v3_from_folder,
+        )
+        loader = MappingPackageV3Loader(include_test_data=include_test_data, include_output=include_output)
+        return load_mapping_package_v3_from_folder(
+            mapping_package_folder_path=package_folder_path,
+            mapping_package_loader=loader,
+        )
     if version == Version.V3L:
+        from mapping_suite_sdk.mapping_package_v3.adapters.mp_v3L_package_loader import (
+            MappingPackageV3LightweightLoader,
+        )
         from mapping_suite_sdk.mapping_package_v3.services.load_mapping_package_v3_lightweight import (
             load_mapping_package_v3_lightweight_from_folder,
         )
+        loader = MappingPackageV3LightweightLoader(
+            include_test_data=include_test_data, include_output=include_output
+        )
         return load_mapping_package_v3_lightweight_from_folder(
             mapping_package_folder_path=package_folder_path,
+            mapping_package_loader=loader,
         )
-    return load_mapping_package_from_folder(version, package_folder_path)
+    raise UnsupportedVersionError(f"Unsupported source version: {version}")
 
 
 def _persist_to_mongodb(
@@ -173,6 +214,7 @@ def load_mapping_package(
     *,
     version: Optional[str] = None,
     include_test_data: bool = False,
+    include_output: bool = True,
     validate_package: bool = True,
     persist_to_mongodb: bool = False,
     mongo_client: Optional[MongoClient] = None,
@@ -192,6 +234,7 @@ def load_mapping_package(
             is detected from the package structure.
         include_test_data: If True, target v3 (full package); if False, target v3L (lightweight).
             Defaults to False.
+        include_output: If True, load output/results artefacts from the package. Defaults to True.
         validate_package: If True, validate the source package before conversion and the
             result after conversion. Validation before conversion fails on invalid hash (no update).
             Defaults to True.
@@ -220,7 +263,9 @@ def load_mapping_package(
     _validate_conversion_path(source_version, target_version)
     _validate_if_requested(package_folder_path, validate_package)
 
-    source_package = _load_source_package(source_version, package_folder_path)
+    source_package = _load_source_package(
+        source_version, package_folder_path, include_test_data=include_test_data, include_output=include_output
+    )
 
     converted = (
         convert_mapping_package_model(source_version, target_version, source_package)

--- a/mapping_suite_sdk/tools/services/load_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/load_mapping_package.py
@@ -178,13 +178,22 @@ def _validate_conversion_path(source_version: Version, target_version: Version) 
         )
 
 
-def _validate_if_requested(package, validate_package: bool) -> None:
+def _validate_if_requested(
+    package,
+    validate_package: bool,
+    include_test_data: bool = False,
+    include_output: bool = False,
+) -> None:
     """Validate package if validation is enabled."""
     if validate_package:
         from mapping_suite_sdk.tools.services.validate_mapping_package import (
             validate_mapping_package,
         )
-        validate_mapping_package(package)
+        validate_mapping_package(
+            package,
+            include_test_data=include_test_data,
+            include_output=include_output,
+        )
 
 
 def _persist_if_requested(
@@ -261,7 +270,12 @@ def load_mapping_package(
     target_version = Version.V3 if include_test_data else Version.V3L
 
     _validate_conversion_path(source_version, target_version)
-    _validate_if_requested(package_folder_path, validate_package)
+    _validate_if_requested(
+        package_folder_path,
+        validate_package,
+        include_test_data=include_test_data,
+        include_output=include_output,
+    )
 
     source_package = _load_source_package(
         source_version, package_folder_path, include_test_data=include_test_data, include_output=include_output
@@ -273,7 +287,12 @@ def load_mapping_package(
         else source_package
     )
 
-    _validate_if_requested(converted, validate_package)
+    _validate_if_requested(
+        converted,
+        validate_package,
+        include_test_data=include_test_data,
+        include_output=include_output,
+    )
 
     return _persist_if_requested(
         converted, persist_to_mongodb, mongo_client, database_name, collection_name

--- a/mapping_suite_sdk/tools/services/load_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/load_mapping_package.py
@@ -223,7 +223,7 @@ def load_mapping_package(
     *,
     version: Optional[str] = None,
     include_test_data: bool = False,
-    include_output: bool = True,
+    include_output: bool = False,
     validate_package: bool = True,
     persist_to_mongodb: bool = False,
     mongo_client: Optional[MongoClient] = None,
@@ -243,7 +243,7 @@ def load_mapping_package(
             is detected from the package structure.
         include_test_data: If True, target v3 (full package); if False, target v3L (lightweight).
             Defaults to False.
-        include_output: If True, load output/results artefacts from the package. Defaults to True.
+        include_output: If True, load output/results artefacts from the package. Defaults to False.
         validate_package: If True, validate the source package before conversion and the
             result after conversion. Validation before conversion fails on invalid hash (no update).
             Defaults to True.

--- a/mapping_suite_sdk/tools/services/validate_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/validate_mapping_package.py
@@ -95,7 +95,31 @@ def _validate_model(mapping_package: MappingPackage, version: Version) -> Litera
     raise CrossVersionValidationError(f"Unsupported version: {version}")
 
 
-def _validate_folder_from_path(path: Path, version: Version) -> Literal[True] | NoReturn:
+def _create_loader_for_version(version: Version, include_test_data: bool, include_output: bool):
+    """Create a version-specific loader with the given flags."""
+    if version == Version.V1:
+        from mapping_suite_sdk.mapping_package_v1.adapters.mp_v1_loader import MappingPackageV1Loader
+        return MappingPackageV1Loader(include_test_data=include_test_data, include_output=include_output)
+    if version == Version.V2:
+        from mapping_suite_sdk.mapping_package_v2.adapters.mp_v2_loader import MappingPackageV2Loader
+        return MappingPackageV2Loader(include_test_data=include_test_data, include_output=include_output)
+    if version == Version.V3:
+        from mapping_suite_sdk.mapping_package_v3.adapters.mp_v3_package_loader import MappingPackageV3Loader
+        return MappingPackageV3Loader(include_test_data=include_test_data, include_output=include_output)
+    if version == Version.V3L:
+        from mapping_suite_sdk.mapping_package_v3.adapters.mp_v3L_package_loader import (
+            MappingPackageV3LightweightLoader,
+        )
+        return MappingPackageV3LightweightLoader(include_test_data=include_test_data, include_output=include_output)
+    raise CrossVersionValidationError(f"Unsupported version: {version}")
+
+
+def _validate_folder_from_path(
+    path: Path,
+    version: Version,
+    include_test_data: bool = False,
+    include_output: bool = False,
+) -> Literal[True] | NoReturn:
     """Call the appropriate version-specific folder validator."""
     from mapping_suite_sdk.mapping_package_v1.services.validate_mapping_package_v1 import validate_mapping_package_v1_from_folder
     from mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2 import validate_mapping_package_v2_from_folder
@@ -104,19 +128,26 @@ def _validate_folder_from_path(path: Path, version: Version) -> Literal[True] | 
         validate_mapping_package_v3_lightweight_from_folder,
     )
 
+    loader = _create_loader_for_version(version, include_test_data, include_output)
+
     if version == Version.V1:
-        return validate_mapping_package_v1_from_folder(mapping_package_folder_path=path)
+        return validate_mapping_package_v1_from_folder(mapping_package_folder_path=path, mapping_package_loader=loader)
     if version == Version.V2:
-        return validate_mapping_package_v2_from_folder(mapping_package_folder_path=path)
+        return validate_mapping_package_v2_from_folder(mapping_package_folder_path=path, mapping_package_loader=loader)
     if version == Version.V3:
-        return validate_mapping_package_v3_from_folder(mapping_package_folder_path=path)
+        return validate_mapping_package_v3_from_folder(mapping_package_folder_path=path, mapping_package_loader=loader)
     if version == Version.V3L:
-        return validate_mapping_package_v3_lightweight_from_folder(mapping_package_folder_path=path)
+        return validate_mapping_package_v3_lightweight_from_folder(mapping_package_folder_path=path, mapping_package_loader=loader)
 
     raise CrossVersionValidationError(f"Unsupported version: {version}")
 
 
-def _validate_archive_path(path: Path, version: Optional[str]) -> Literal[True] | NoReturn:
+def _validate_archive_path(
+    path: Path,
+    version: Optional[str],
+    include_test_data: bool = False,
+    include_output: bool = False,
+) -> Literal[True] | NoReturn:
     """Validate a mapping package from an archive file."""
     MPValidationStepABC.validate_archive_path(path, context="validate mapping package archive")
     extractor = ArchiveExtractor()
@@ -126,26 +157,36 @@ def _validate_archive_path(path: Path, version: Optional[str]) -> Literal[True] 
         detected = _normalize_version(version) if version else detect_mapping_package_version(extracted_folder)
         if not detected:
             raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
-        return _validate_folder_from_path(extracted_folder, detected)
+        return _validate_folder_from_path(extracted_folder, detected, include_test_data, include_output)
 
 
-def _validate_folder_path(path: Path, version: Optional[str]) -> Literal[True] | NoReturn:
+def _validate_folder_path(
+    path: Path,
+    version: Optional[str],
+    include_test_data: bool = False,
+    include_output: bool = False,
+) -> Literal[True] | NoReturn:
     """Validate a mapping package from a folder path."""
     MPValidationStepABC.validate_folder_path(path, context="validate mapping package folder")
     detected = _normalize_version(version) if version else detect_mapping_package_version(path)
     if not detected:
         raise CrossVersionValidationError(f"Unknown or unsupported mapping package version for: {path}")
-    return _validate_folder_from_path(path, detected)
+    return _validate_folder_from_path(path, detected, include_test_data, include_output)
 
 
-def _validate_path(path: Path, version: Optional[str]) -> Literal[True] | NoReturn:
+def _validate_path(
+    path: Path,
+    version: Optional[str],
+    include_test_data: bool = False,
+    include_output: bool = False,
+) -> Literal[True] | NoReturn:
     """Validate a mapping package from a Path (file or folder)."""
     MPValidationStepABC.validate_path_exists(path, context="validate mapping package")
 
     if path.is_file():
-        return _validate_archive_path(path, version)
+        return _validate_archive_path(path, version, include_test_data, include_output)
     
-    return _validate_folder_path(path, version)
+    return _validate_folder_path(path, version, include_test_data, include_output)
 
 
 def _detect_version_from_model(mapping_package: MappingPackage) -> Version:
@@ -171,6 +212,8 @@ def _detect_version_from_model(mapping_package: MappingPackage) -> Version:
 def validate_mapping_package(
     mapping_package: Path | MappingPackage,
     version: Optional[str] = None,
+    include_test_data: bool = False,
+    include_output: bool = False,
 ) -> Literal[True] | NoReturn:
     """
     Validate a mapping package using version-specific logic, with optional auto-detection.
@@ -183,12 +226,14 @@ def validate_mapping_package(
     Args:
         mapping_package: Either a mapping package model instance or a folder/archive path.
         version: Optional explicit version ("v1", "v2", "v3", "v3L"). When provided, version detection is skipped.
+        include_test_data: If True, load test data during validation. Defaults to False.
+        include_output: If True, load output artefacts during validation. Defaults to False.
 
     Returns:
         True if validation passes, otherwise raises.
     """
     if isinstance(mapping_package, Path):
-        return _validate_path(mapping_package, version)
+        return _validate_path(mapping_package, version, include_test_data, include_output)
 
     # Model instance case
     detected = _normalize_version(version) if version else _detect_version_from_model(mapping_package)

--- a/mapping_suite_sdk/tools/services/validate_mapping_package.py
+++ b/mapping_suite_sdk/tools/services/validate_mapping_package.py
@@ -136,10 +136,8 @@ def _validate_folder_from_path(
         return validate_mapping_package_v2_from_folder(mapping_package_folder_path=path, mapping_package_loader=loader)
     if version == Version.V3:
         return validate_mapping_package_v3_from_folder(mapping_package_folder_path=path, mapping_package_loader=loader)
-    if version == Version.V3L:
-        return validate_mapping_package_v3_lightweight_from_folder(mapping_package_folder_path=path, mapping_package_loader=loader)
-
-    raise CrossVersionValidationError(f"Unsupported version: {version}")
+    # V3L is the only remaining valid version (invalid versions already rejected by _create_loader_for_version)
+    return validate_mapping_package_v3_lightweight_from_folder(mapping_package_folder_path=path, mapping_package_loader=loader)
 
 
 def _validate_archive_path(

--- a/tests/unit/tools/services/test_load_mapping_package.py
+++ b/tests/unit/tools/services/test_load_mapping_package.py
@@ -292,8 +292,12 @@ class TestLoadMappingPackageValidation:
             validate_package=True,
         )
         assert mock_validate.call_count == 2
-        assert mock_validate.call_args_list[0] == call(tmp_path)
-        assert mock_validate.call_args_list[1] == call(converted)
+        assert mock_validate.call_args_list[0] == call(
+            tmp_path, include_test_data=True, include_output=True
+        )
+        assert mock_validate.call_args_list[1] == call(
+            converted, include_test_data=True, include_output=True
+        )
 
     @patch(
         "mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package"

--- a/tests/unit/tools/services/test_load_mapping_package.py
+++ b/tests/unit/tools/services/test_load_mapping_package.py
@@ -243,7 +243,7 @@ class TestLoadMappingPackageLoaderFlags:
 
     @patch(_V3_LOAD)
     @patch(_V3_LOADER)
-    def test_include_output_defaults_to_true(
+    def test_include_output_defaults_to_false(
         self, mock_loader_cls, mock_load, tmp_path: Path
     ):
         mock_instance = Mock()
@@ -252,7 +252,7 @@ class TestLoadMappingPackageLoaderFlags:
         load_mapping_package(
             tmp_path, version="v3", include_test_data=True, validate_package=False
         )
-        mock_loader_cls.assert_called_once_with(include_test_data=True, include_output=True)
+        mock_loader_cls.assert_called_once_with(include_test_data=True, include_output=False)
 
     @patch(_V3_LOAD)
     @patch(_V3_LOADER)
@@ -293,10 +293,10 @@ class TestLoadMappingPackageValidation:
         )
         assert mock_validate.call_count == 2
         assert mock_validate.call_args_list[0] == call(
-            tmp_path, include_test_data=True, include_output=True
+            tmp_path, include_test_data=True, include_output=False
         )
         assert mock_validate.call_args_list[1] == call(
-            converted, include_test_data=True, include_output=True
+            converted, include_test_data=True, include_output=False
         )
 
     @patch(

--- a/tests/unit/tools/services/test_load_mapping_package.py
+++ b/tests/unit/tools/services/test_load_mapping_package.py
@@ -24,6 +24,7 @@ from mapping_suite_sdk.tools.services.load_mapping_package import (
     UnsupportedConversionError,
     UnsupportedVersionError,
     VersionDetectionError,
+    _load_source_package,
     load_mapping_package,
 )
 
@@ -94,6 +95,15 @@ class TestLoadMappingPackageVersionHandling:
     def test_unsupported_version_string_raises(self, tmp_path: Path):
         with pytest.raises(UnsupportedVersionError, match="Unsupported version"):
             load_mapping_package(tmp_path, version="v99", validate_package=False)
+
+    def test_load_source_package_unsupported_source_version_raises(self, tmp_path: Path):
+        with pytest.raises(UnsupportedVersionError, match="Unsupported source version"):
+            _load_source_package(
+                "v99",
+                tmp_path,
+                include_test_data=False,
+                include_output=False,
+            )
 
     @patch(_V3L_LOAD)
     def test_version_normalized_case_insensitive_v3l(self, mock_v3l_load, tmp_path: Path):

--- a/tests/unit/tools/services/test_load_mapping_package.py
+++ b/tests/unit/tools/services/test_load_mapping_package.py
@@ -4,12 +4,13 @@ Unit tests for the load_mapping_package service.
 Tests focus on service-layer orchestration:
 - Path and version handling
 - Version detection and routing
+- Loader construction with include_test_data / include_output flags
 - Optional validation (before and after conversion)
 - Target version from include_test_data
 - Optional MongoDB persistence
 """
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 
@@ -25,6 +26,18 @@ from mapping_suite_sdk.tools.services.load_mapping_package import (
     VersionDetectionError,
     load_mapping_package,
 )
+
+# Patch targets for version-specific service functions (lazy-imported inside _load_source_package)
+_V1_LOAD = "mapping_suite_sdk.mapping_package_v1.services.load_mapping_package_v1.load_mapping_package_v1_from_folder"
+_V2_LOAD = "mapping_suite_sdk.mapping_package_v2.services.load_mapping_package_v2.load_mapping_package_v2_from_folder"
+_V3_LOAD = "mapping_suite_sdk.mapping_package_v3.services.load_mapping_package_v3.load_mapping_package_v3_from_folder"
+_V3L_LOAD = "mapping_suite_sdk.mapping_package_v3.services.load_mapping_package_v3_lightweight.load_mapping_package_v3_lightweight_from_folder"
+
+# Patch targets for loader constructors
+_V1_LOADER = "mapping_suite_sdk.mapping_package_v1.adapters.mp_v1_loader.MappingPackageV1Loader"
+_V2_LOADER = "mapping_suite_sdk.mapping_package_v2.adapters.mp_v2_loader.MappingPackageV2Loader"
+_V3_LOADER = "mapping_suite_sdk.mapping_package_v3.adapters.mp_v3_package_loader.MappingPackageV3Loader"
+_V3L_LOADER = "mapping_suite_sdk.mapping_package_v3.adapters.mp_v3L_package_loader.MappingPackageV3LightweightLoader"
 
 
 class TestLoadMappingPackagePathValidation:
@@ -45,21 +58,21 @@ class TestLoadMappingPackagePathValidation:
 class TestLoadMappingPackageVersionHandling:
     """Explicit version and auto-detection."""
 
-    @patch(
-        "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-    )
+    @patch(_V3_LOAD)
     def test_explicit_version_skips_detection(self, mock_load, tmp_path: Path):
         mock_load.return_value = Mock(spec=MappingPackageV3)
-        load_mapping_package(tmp_path, version="v3", include_test_data=True, validate_package=False)
-        mock_load.assert_called_once_with(Version.V3, tmp_path)
+        with patch(
+            "mapping_suite_sdk.tools.services.load_mapping_package.detect_mapping_package_version"
+        ) as mock_detect:
+            load_mapping_package(tmp_path, version="v3", include_test_data=True, validate_package=False)
+            mock_detect.assert_not_called()
+        mock_load.assert_called_once()
 
+    @patch(_V2_LOAD)
     @patch(
         "mapping_suite_sdk.tools.services.load_mapping_package.detect_mapping_package_version"
     )
-    @patch(
-        "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-    )
-    def test_no_version_triggers_detection(self, mock_load, mock_detect, tmp_path: Path):
+    def test_no_version_triggers_detection(self, mock_detect, mock_load, tmp_path: Path):
         mock_detect.return_value = "v2"
         mock_load.return_value = Mock(spec=MappingPackageV3)
         with patch(
@@ -68,7 +81,7 @@ class TestLoadMappingPackageVersionHandling:
             mock_convert.return_value = Mock(spec=MappingPackageV3)
             load_mapping_package(tmp_path, include_test_data=True, validate_package=False)
         mock_detect.assert_called_once_with(tmp_path)
-        mock_load.assert_called_once_with(Version.V2, tmp_path)
+        mock_load.assert_called_once()
 
     @patch(
         "mapping_suite_sdk.tools.services.load_mapping_package.detect_mapping_package_version"
@@ -82,32 +95,25 @@ class TestLoadMappingPackageVersionHandling:
         with pytest.raises(UnsupportedVersionError, match="Unsupported version"):
             load_mapping_package(tmp_path, version="v99", validate_package=False)
 
-    @patch(
-        "mapping_suite_sdk.mapping_package_v3.services.load_mapping_package_v3_lightweight.load_mapping_package_v3_lightweight_from_folder"
-    )
+    @patch(_V3L_LOAD)
     def test_version_normalized_case_insensitive_v3l(self, mock_v3l_load, tmp_path: Path):
         mock_v3l_load.return_value = Mock(spec=MappingPackageV3Lightweight)
         result = load_mapping_package(
             tmp_path, version="  v3L  ", include_test_data=False, validate_package=False
         )
-        mock_v3l_load.assert_called_once_with(
-            mapping_package_folder_path=tmp_path,
-        )
+        mock_v3l_load.assert_called_once()
+        assert mock_v3l_load.call_args[1]["mapping_package_folder_path"] == tmp_path
         assert result is mock_v3l_load.return_value
 
 
 class TestLoadMappingPackageIncludeTestDataAndConversion:
     """Target version (v3 vs v3L) and conversion routing."""
 
+    @patch(_V2_LOAD)
     @patch(
         "mapping_suite_sdk.tools.services.load_mapping_package.convert_mapping_package_model"
     )
-    @patch(
-        "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-    )
-    def test_include_test_data_true_targets_v3(
-        self, mock_load, mock_convert, tmp_path: Path
-    ):
+    def test_include_test_data_true_targets_v3(self, mock_convert, mock_load, tmp_path: Path):
         source = Mock(spec=MappingPackageV3)
         converted = Mock(spec=MappingPackageV3)
         mock_load.return_value = source
@@ -118,15 +124,11 @@ class TestLoadMappingPackageIncludeTestDataAndConversion:
         mock_convert.assert_called_once_with(Version.V2, Version.V3, source)
         assert result is converted
 
+    @patch(_V3_LOAD)
     @patch(
         "mapping_suite_sdk.tools.services.load_mapping_package.convert_mapping_package_model"
     )
-    @patch(
-        "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-    )
-    def test_include_test_data_false_targets_v3l(
-        self, mock_load, mock_convert, tmp_path: Path
-    ):
+    def test_include_test_data_false_targets_v3l(self, mock_convert, mock_load, tmp_path: Path):
         source = Mock(spec=MappingPackageV3)
         converted = Mock(spec=MappingPackageV3Lightweight)
         mock_load.return_value = source
@@ -137,9 +139,7 @@ class TestLoadMappingPackageIncludeTestDataAndConversion:
         mock_convert.assert_called_once_with(Version.V3, Version.V3L, source)
         assert result is converted
 
-    @patch(
-        "mapping_suite_sdk.mapping_package_v3.services.load_mapping_package_v3_lightweight.load_mapping_package_v3_lightweight_from_folder"
-    )
+    @patch(_V3L_LOAD)
     def test_v3l_source_with_include_test_data_true_raises(
         self, mock_v3l_load, tmp_path: Path
     ):
@@ -152,9 +152,7 @@ class TestLoadMappingPackageIncludeTestDataAndConversion:
                 tmp_path, version="v3L", include_test_data=True, validate_package=False
             )
 
-    @patch(
-        "mapping_suite_sdk.mapping_package_v3.services.load_mapping_package_v3_lightweight.load_mapping_package_v3_lightweight_from_folder"
-    )
+    @patch(_V3L_LOAD)
     def test_v3l_source_with_include_test_data_false_returns_without_conversion(
         self, mock_v3l_load, tmp_path: Path
     ):
@@ -170,20 +168,108 @@ class TestLoadMappingPackageIncludeTestDataAndConversion:
         assert result is pkg
 
 
+class TestLoadMappingPackageLoaderFlags:
+    """Loader is constructed with include_test_data and include_output flags."""
+
+    @patch(_V1_LOAD)
+    @patch(_V1_LOADER)
+    def test_include_output_false_passed_to_v1_loader(
+        self, mock_loader_cls, mock_load, tmp_path: Path
+    ):
+        mock_instance = Mock()
+        mock_loader_cls.return_value = mock_instance
+        mock_load.return_value = Mock(spec=MappingPackageV3)
+        with patch(
+            "mapping_suite_sdk.tools.services.load_mapping_package.convert_mapping_package_model"
+        ) as mock_convert:
+            mock_convert.return_value = Mock(spec=MappingPackageV3)
+            load_mapping_package(
+                tmp_path, version="v1", include_test_data=True, include_output=False, validate_package=False
+            )
+        mock_loader_cls.assert_called_once_with(include_test_data=True, include_output=False)
+
+    @patch(_V2_LOAD)
+    @patch(_V2_LOADER)
+    def test_include_output_false_passed_to_v2_loader(
+        self, mock_loader_cls, mock_load, tmp_path: Path
+    ):
+        mock_instance = Mock()
+        mock_loader_cls.return_value = mock_instance
+        mock_load.return_value = Mock(spec=MappingPackageV3)
+        with patch(
+            "mapping_suite_sdk.tools.services.load_mapping_package.convert_mapping_package_model"
+        ) as mock_convert:
+            mock_convert.return_value = Mock(spec=MappingPackageV3)
+            load_mapping_package(
+                tmp_path, version="v2", include_test_data=True, include_output=False, validate_package=False
+            )
+        mock_loader_cls.assert_called_once_with(include_test_data=True, include_output=False)
+
+    @patch(_V3_LOAD)
+    @patch(_V3_LOADER)
+    def test_include_output_false_passed_to_v3_loader(
+        self, mock_loader_cls, mock_load, tmp_path: Path
+    ):
+        mock_instance = Mock()
+        mock_loader_cls.return_value = mock_instance
+        mock_load.return_value = Mock(spec=MappingPackageV3)
+        load_mapping_package(
+            tmp_path, version="v3", include_test_data=True, include_output=False, validate_package=False
+        )
+        mock_loader_cls.assert_called_once_with(include_test_data=True, include_output=False)
+
+    @patch(_V3L_LOAD)
+    @patch(_V3L_LOADER)
+    def test_include_output_false_passed_to_v3l_loader(
+        self, mock_loader_cls, mock_load, tmp_path: Path
+    ):
+        mock_instance = Mock()
+        mock_loader_cls.return_value = mock_instance
+        mock_load.return_value = Mock(spec=MappingPackageV3Lightweight)
+        load_mapping_package(
+            tmp_path, version="v3L", include_test_data=False, include_output=False, validate_package=False
+        )
+        mock_loader_cls.assert_called_once_with(include_test_data=False, include_output=False)
+
+    @patch(_V3_LOAD)
+    @patch(_V3_LOADER)
+    def test_include_output_defaults_to_true(
+        self, mock_loader_cls, mock_load, tmp_path: Path
+    ):
+        mock_instance = Mock()
+        mock_loader_cls.return_value = mock_instance
+        mock_load.return_value = Mock(spec=MappingPackageV3)
+        load_mapping_package(
+            tmp_path, version="v3", include_test_data=True, validate_package=False
+        )
+        mock_loader_cls.assert_called_once_with(include_test_data=True, include_output=True)
+
+    @patch(_V3_LOAD)
+    @patch(_V3_LOADER)
+    def test_loader_instance_passed_to_service_function(
+        self, mock_loader_cls, mock_load, tmp_path: Path
+    ):
+        mock_instance = Mock()
+        mock_loader_cls.return_value = mock_instance
+        mock_load.return_value = Mock(spec=MappingPackageV3)
+        load_mapping_package(
+            tmp_path, version="v3", include_test_data=True, validate_package=False
+        )
+        assert mock_load.call_args[1]["mapping_package_loader"] is mock_instance
+
+
 class TestLoadMappingPackageValidation:
     """Optional validation before and after conversion."""
 
     @patch(
         "mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package"
     )
+    @patch(_V2_LOAD)
     @patch(
         "mapping_suite_sdk.tools.services.load_mapping_package.convert_mapping_package_model"
     )
-    @patch(
-        "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-    )
     def test_validate_package_true_validates_before_and_after(
-        self, mock_load, mock_convert, mock_validate, tmp_path: Path
+        self, mock_convert, mock_load, mock_validate, tmp_path: Path
     ):
         source = Mock(spec=MappingPackageV3)
         converted = Mock(spec=MappingPackageV3)
@@ -196,19 +282,13 @@ class TestLoadMappingPackageValidation:
             validate_package=True,
         )
         assert mock_validate.call_count == 2
-        first_call = mock_validate.call_args_list[0]
-        second_call = mock_validate.call_args_list[1]
-        # First validation: validate the folder path before conversion
-        assert first_call[0][0] == tmp_path
-        # Second validation: validate the converted package after conversion
-        assert second_call[0][0] is converted
+        assert mock_validate.call_args_list[0] == call(tmp_path)
+        assert mock_validate.call_args_list[1] == call(converted)
 
     @patch(
         "mapping_suite_sdk.tools.services.validate_mapping_package.validate_mapping_package"
     )
-    @patch(
-        "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-    )
+    @patch(_V3_LOAD)
     def test_validate_package_false_skips_validation(
         self, mock_load, mock_validate, tmp_path: Path
     ):
@@ -225,9 +305,7 @@ class TestLoadMappingPackageMongoDBPersistence:
     @patch(
         "mapping_suite_sdk.tools.services.load_mapping_package._persist_to_mongodb"
     )
-    @patch(
-        "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-    )
+    @patch(_V3_LOAD)
     def test_persist_to_mongodb_calls_saver(
         self, mock_load, mock_persist, tmp_path: Path
     ):
@@ -245,39 +323,33 @@ class TestLoadMappingPackageMongoDBPersistence:
             collection_name="coll",
             validate_package=False,
         )
-        mock_persist.assert_called_once_with(
-            pkg, client, "db", "coll"
-        )
+        mock_persist.assert_called_once_with(pkg, client, "db", "coll")
 
-    def test_persist_to_mongodb_without_client_raises(self, tmp_path: Path):
-        with patch(
-            "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-        ) as mock_load:
-            mock_load.return_value = Mock(spec=MappingPackageV3)
-            with pytest.raises(ValueError, match="mongo_client and database_name"):
-                load_mapping_package(
-                    tmp_path,
-                    version="v3",
-                    include_test_data=True,
-                    persist_to_mongodb=True,
-                    database_name="db",
-                    validate_package=False,
-                )
+    @patch(_V3_LOAD)
+    def test_persist_to_mongodb_without_client_raises(self, mock_load, tmp_path: Path):
+        mock_load.return_value = Mock(spec=MappingPackageV3)
+        with pytest.raises(ValueError, match="mongo_client and database_name"):
+            load_mapping_package(
+                tmp_path,
+                version="v3",
+                include_test_data=True,
+                persist_to_mongodb=True,
+                database_name="db",
+                validate_package=False,
+            )
 
-    def test_persist_to_mongodb_without_database_name_raises(self, tmp_path: Path):
-        with patch(
-            "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-        ) as mock_load:
-            mock_load.return_value = Mock(spec=MappingPackageV3)
-            with pytest.raises(ValueError, match="mongo_client and database_name"):
-                load_mapping_package(
-                    tmp_path,
-                    version="v3",
-                    include_test_data=True,
-                    persist_to_mongodb=True,
-                    mongo_client=MagicMock(),
-                    validate_package=False,
-                )
+    @patch(_V3_LOAD)
+    def test_persist_to_mongodb_without_database_name_raises(self, mock_load, tmp_path: Path):
+        mock_load.return_value = Mock(spec=MappingPackageV3)
+        with pytest.raises(ValueError, match="mongo_client and database_name"):
+            load_mapping_package(
+                tmp_path,
+                version="v3",
+                include_test_data=True,
+                persist_to_mongodb=True,
+                mongo_client=MagicMock(),
+                validate_package=False,
+            )
 
     @patch(
         "mapping_suite_sdk.mapping_package_v3.services.save_mapping_package_v3_lightweight.save_mapping_package_v3_lightweight_to_mongo_db"
@@ -355,14 +427,12 @@ class TestLoadMappingPackageMongoDBPersistence:
 class TestLoadMappingPackageV3NoConversion:
     """When source is already target version, no conversion."""
 
+    @patch(_V3_LOAD)
     @patch(
         "mapping_suite_sdk.tools.services.load_mapping_package.convert_mapping_package_model"
     )
-    @patch(
-        "mapping_suite_sdk.tools.services.load_mapping_package.load_mapping_package_from_folder"
-    )
     def test_v3_source_target_v3_returns_same_instance(
-        self, mock_load, mock_convert, tmp_path: Path
+        self, mock_convert, mock_load, tmp_path: Path
     ):
         pkg = Mock(spec=MappingPackageV3)
         mock_load.return_value = pkg

--- a/tests/unit/tools/services/test_validate_mapping_package.py
+++ b/tests/unit/tools/services/test_validate_mapping_package.py
@@ -5,6 +5,10 @@ import pytest
 from typing import cast
 
 from mapping_suite_sdk.core.adapters.validator import MPValidationException
+from mapping_suite_sdk.mapping_package_v1.adapters.mp_v1_loader import MappingPackageV1Loader
+from mapping_suite_sdk.mapping_package_v2.adapters.mp_v2_loader import MappingPackageV2Loader
+from mapping_suite_sdk.mapping_package_v3.adapters.mp_v3_package_loader import MappingPackageV3Loader
+from mapping_suite_sdk.mapping_package_v3.adapters.mp_v3L_package_loader import MappingPackageV3LightweightLoader
 from mapping_suite_sdk.tools.services.convert_mapping_package import Version
 from mapping_suite_sdk.tools.services.convert_mapping_package_v3_to_v3_lightweight import (
     convert_mapping_package_v3_to_v3_lightweight,
@@ -19,6 +23,14 @@ from mapping_suite_sdk.tools.services.validate_mapping_package import (
 )
 
 
+def _assert_loader(mock_call, expected_loader_type, include_test_data=False, include_output=False):
+    """Assert loader type and configuration in mock call."""
+    loader = mock_call.call_args.kwargs["mapping_package_loader"]
+    assert isinstance(loader, expected_loader_type), f"Expected {expected_loader_type}, got {type(loader)}"
+    assert loader.include_test_data == include_test_data
+    assert loader.include_output == include_output
+
+
 def test_validate_mapping_package_auto_detects_version_for_folder_path(tmp_path: Path) -> None:
     """Test that version is auto-detected when validating a folder path without explicit version."""
     with (
@@ -27,7 +39,9 @@ def test_validate_mapping_package_auto_detects_version_for_folder_path(tmp_path:
     ):
         assert validate_mapping_package(tmp_path) is True
         mock_detect.assert_called_once_with(tmp_path)
-        mock_v2.assert_called_once_with(mapping_package_folder_path=tmp_path)
+        mock_v2.assert_called_once()
+        assert mock_v2.call_args.kwargs["mapping_package_folder_path"] == tmp_path
+        _assert_loader(mock_v2, MappingPackageV2Loader, include_test_data=False, include_output=False)
 
 
 def test_validate_mapping_package_explicit_version_skips_detection_for_folder_path(tmp_path: Path) -> None:
@@ -38,7 +52,9 @@ def test_validate_mapping_package_explicit_version_skips_detection_for_folder_pa
     ):
         assert validate_mapping_package(tmp_path, version="v3") is True
         mock_detect.assert_not_called()
-        mock_v3.assert_called_once_with(mapping_package_folder_path=tmp_path)
+        mock_v3.assert_called_once()
+        assert mock_v3.call_args.kwargs["mapping_package_folder_path"] == tmp_path
+        _assert_loader(mock_v3, MappingPackageV3Loader, include_test_data=False, include_output=False)
 
 
 def test_validate_mapping_package_raises_clear_error_for_unknown_version(tmp_path: Path) -> None:
@@ -207,7 +223,9 @@ def test_validate_folder_from_path_v1_calls_v1_from_folder(tmp_path: Path) -> No
         return_value=True,
     ) as mock_v1:
         assert _validate_folder_from_path(tmp_path, Version.V1) is True
-        mock_v1.assert_called_once_with(mapping_package_folder_path=tmp_path)
+        mock_v1.assert_called_once()
+        assert mock_v1.call_args.kwargs["mapping_package_folder_path"] == tmp_path
+        _assert_loader(mock_v1, MappingPackageV1Loader, include_test_data=False, include_output=False)
 
 
 def test_validate_folder_from_path_v2_calls_v2_from_folder(tmp_path: Path) -> None:
@@ -217,7 +235,9 @@ def test_validate_folder_from_path_v2_calls_v2_from_folder(tmp_path: Path) -> No
         return_value=True,
     ) as mock_v2:
         assert _validate_folder_from_path(tmp_path, Version.V2) is True
-        mock_v2.assert_called_once_with(mapping_package_folder_path=tmp_path)
+        mock_v2.assert_called_once()
+        assert mock_v2.call_args.kwargs["mapping_package_folder_path"] == tmp_path
+        _assert_loader(mock_v2, MappingPackageV2Loader, include_test_data=False, include_output=False)
 
 
 def test_validate_folder_from_path_v3_calls_v3_from_folder(tmp_path: Path) -> None:
@@ -227,7 +247,9 @@ def test_validate_folder_from_path_v3_calls_v3_from_folder(tmp_path: Path) -> No
         return_value=True,
     ) as mock_v3:
         assert _validate_folder_from_path(tmp_path, Version.V3) is True
-        mock_v3.assert_called_once_with(mapping_package_folder_path=tmp_path)
+        mock_v3.assert_called_once()
+        assert mock_v3.call_args.kwargs["mapping_package_folder_path"] == tmp_path
+        _assert_loader(mock_v3, MappingPackageV3Loader, include_test_data=False, include_output=False)
 
 
 def test_validate_folder_from_path_v3L_calls_v3_lightweight_from_folder(tmp_path: Path) -> None:
@@ -237,7 +259,49 @@ def test_validate_folder_from_path_v3L_calls_v3_lightweight_from_folder(tmp_path
         return_value=True,
     ) as mock_v3l:
         assert _validate_folder_from_path(tmp_path, Version.V3L) is True
-        mock_v3l.assert_called_once_with(mapping_package_folder_path=tmp_path)
+        mock_v3l.assert_called_once()
+        assert mock_v3l.call_args.kwargs["mapping_package_folder_path"] == tmp_path
+        _assert_loader(mock_v3l, MappingPackageV3LightweightLoader, include_test_data=False, include_output=False)
+
+
+def test_validate_folder_from_path_propagates_include_test_data(tmp_path: Path) -> None:
+    """Test that include_test_data is propagated to the loader."""
+    with patch(
+        "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3_from_folder",
+        return_value=True,
+    ) as mock_v3:
+        assert _validate_folder_from_path(tmp_path, Version.V3, include_test_data=True) is True
+        _assert_loader(mock_v3, MappingPackageV3Loader, include_test_data=True, include_output=False)
+
+
+def test_validate_folder_from_path_propagates_include_output(tmp_path: Path) -> None:
+    """Test that include_output is propagated to the loader."""
+    with patch(
+        "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3_from_folder",
+        return_value=True,
+    ) as mock_v3:
+        assert _validate_folder_from_path(tmp_path, Version.V3, include_output=True) is True
+        _assert_loader(mock_v3, MappingPackageV3Loader, include_test_data=False, include_output=True)
+
+
+def test_validate_folder_from_path_propagates_both_flags(tmp_path: Path) -> None:
+    """Test that both include_test_data and include_output are propagated to the loader."""
+    with patch(
+        "mapping_suite_sdk.mapping_package_v2.services.validate_mapping_package_v2.validate_mapping_package_v2_from_folder",
+        return_value=True,
+    ) as mock_v2:
+        assert _validate_folder_from_path(tmp_path, Version.V2, include_test_data=True, include_output=True) is True
+        _assert_loader(mock_v2, MappingPackageV2Loader, include_test_data=True, include_output=True)
+
+
+def test_validate_mapping_package_propagates_flags_to_folder_validation(tmp_path: Path) -> None:
+    """Test that validate_mapping_package propagates include_test_data and include_output to folder validation."""
+    with patch(
+        "mapping_suite_sdk.mapping_package_v3.services.validate_mapping_package_v3.validate_mapping_package_v3_from_folder",
+        return_value=True,
+    ) as mock_v3:
+        assert validate_mapping_package(tmp_path, version="v3", include_test_data=True, include_output=True) is True
+        _assert_loader(mock_v3, MappingPackageV3Loader, include_test_data=True, include_output=True)
 
 
 # --- _detect_version_from_model ---
@@ -395,7 +459,9 @@ def test_validate_mapping_package_archive_succeeds_with_auto_detection(tmp_path:
         assert call_args[0] == archive_path
 
         mock_detect.assert_called_once_with(extracted_path)
-        mock_v2.assert_called_once_with(mapping_package_folder_path=extracted_path)
+        mock_v2.assert_called_once()
+        assert mock_v2.call_args.kwargs["mapping_package_folder_path"] == extracted_path
+        _assert_loader(mock_v2, MappingPackageV2Loader, include_test_data=False, include_output=False)
 
 
 def test_validate_mapping_package_archive_succeeds_with_explicit_version(tmp_path: Path) -> None:
@@ -426,7 +492,9 @@ def test_validate_mapping_package_archive_succeeds_with_explicit_version(tmp_pat
         assert call_args[0] == archive_path
 
         mock_detect.assert_not_called()
-        mock_v3.assert_called_once_with(mapping_package_folder_path=extracted_path)
+        mock_v3.assert_called_once()
+        assert mock_v3.call_args.kwargs["mapping_package_folder_path"] == extracted_path
+        _assert_loader(mock_v3, MappingPackageV3Loader, include_test_data=False, include_output=False)
 
 
 # --- validate_mapping_package: model validation ---


### PR DESCRIPTION
Propagate include_test_data and include_output through shortcut loading service.

This updates load_mapping_package() so the shortcut loading path no longer ignores loader inclusion flags. The service now exposes include_output and explicitly constructs version-specific loaders and validators with both include_test_data and include_output, ensuring the top-level API behaves consistently with lower-level functions.

https://meaningfy.atlassian.net/browse/MSSDK1-124