### PR TITLE
Cap Python max version to 3.12 generally, update docs

### DIFF
--- a/.github/workflows/release-tag-pypi-publish.yaml
+++ b/.github/workflows/release-tag-pypi-publish.yaml
@@ -16,4 +16,5 @@ jobs:
       - name: Build and publish to pypi
         uses: JRubics/poetry-publish@v2.1
         with:
+          python_version: "3.12"
           pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ This structure supports consistent loading, validation, and conversion across ve
 
 ## Quick Start
 
+**Requires Python 3.10–3.12** (Python 3.13+ is not yet supported due to pandas 2.1.4 compatibility, which is currently needed by some of our users)
+
 Install the SDK using pip:
 ```bash
 pip install mapping-suite-sdk

--- a/docs/modules/ROOT/pages/quick-start.adoc
+++ b/docs/modules/ROOT/pages/quick-start.adoc
@@ -38,6 +38,8 @@ mapping-package/
 
 == Installation
 
+**Requires Python 3.10–3.12** (Python 3.13+ is not yet supported due to pandas 2.1.4 compatibility, which is currently needed by some of our users)
+
 Install the Mapping Suite SDK using your preferred package manager.
 
 === Using pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "meaningfy.ws", email = "hi@meaningfy.ws" }
 ]
 readme = "README.md"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "pydantic>=2.10.0,<3.0.0",
     "pandas==2.1.4",


### PR DESCRIPTION
Initially required by PyPi publishing, as the Pandas pin to 2.1.4 did not allow dependency resolution in Python 3.13. Apply the hard cap in Poetry so that consistency is maintained in user environments. Update docs accordingly.